### PR TITLE
Fixed an error I introduced. Added test to check that files are created.

### DIFF
--- a/src/cycax/cycad/assembly.py
+++ b/src/cycax/cycad/assembly.py
@@ -36,18 +36,16 @@ class Assembly:
             # FIXME: Should just be: `part.render()` the part render should sort out its own stuff.
             name = part["part_no"]
 
-            STLname = "{cwd}/{name}/{name}.stl".format(cwd=self._base_path, name=name)
-            if not os.path.exists(STLname):
-                SCADname = "{cwd}/{name}/{name}.scad".format(cwd=self._base_path, name=name)
-                if not os.path.exists(SCADname):
-                    logging.info("Creating a SCAD file of the pieces of the object.")
+            stl_name = "{cwd}/{name}/{name}.stl".format(cwd=self._base_path, name=name)
+            if not os.path.exists(stl_name):
+                scad_name = "{cwd}/{name}/{name}.scad".format(cwd=self._base_path, name=name)
+                if not os.path.exists(scad_name):
+                    logging.info("Creating SCAD file %s of the pieces of the object.", scad_name)
                     self.decoder.decode(name)
-                else:
-                    pass
                 self.decoder.render_stl(name)
 
         logging.info("Calling to the assembler")
-        self.assembler.assembly_openscad()
+        self.assembler.assembly_openscad(self._base_path)
 
     def save(self, path: Path | None = None):
         """

--- a/src/cycax/cycad/assembly_openscad.py
+++ b/src/cycax/cycad/assembly_openscad.py
@@ -101,12 +101,9 @@ class AssemblyOpenSCAD:
         """
         if path is not None:
             self._base_path = path
-        out_name = "{cwd}/{part_no}/{part_no}.scad".format(cwd=self._base_path, part_no=self.part_no)
-        SCAD = open(out_name, "w")
-        in_name = "{cwd}/{part_no}/{part_no}.json".format(cwd=self._base_path, part_no=self.part_no)
-        with open(in_name) as f:
-            data = json.load(f)
-        f.close()
+
+        json_file = self._base_path / f"{self.part_no}.json"
+        data = json.loads(json_file.read_text())
 
         output = []
         for action in data:
@@ -114,8 +111,8 @@ class AssemblyOpenSCAD:
             output.append(self._colour(action["colour"]))
             output.append(self._fetch_part(action["part_no"]))
 
-        for out in output:
-            SCAD.write(out)
-            SCAD.write("\n")
-
-        SCAD.close()
+        scad_file = self._base_path / f"{self.part_no}.scad"
+        with scad_file.open("w") as scad_fh:
+            for out in output:
+                scad_fh.write(out)
+                scad_fh.write("\n")

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -12,6 +12,12 @@ def check_json_file(dir_path: Path, name: str):
     json.loads(json_file.read_text())
 
 
+def check_files(dir_path: Path, name: str, file_extensions: list[str]):
+    for ext in file_extensions:
+        file_path = dir_path / f"{name}.{ext}"
+        assert file_path.exists(), "File should exists"
+
+
 def test_save(tmp_path):
     """Test save on assembly and parts."""
 
@@ -28,3 +34,25 @@ def test_save(tmp_path):
         part_expected_path = tmp_path / f"part-test{i}"
         assert part_expected_path.is_dir(), "Directory for part should exists"
         check_json_file(part_expected_path, f"part-test{i}")
+
+
+def test_render(tmp_path):
+    """Test render on assembly and parts."""
+
+    assert len(tuple(tmp_path.glob("*"))) == 0, "Test directory should be empty"
+    assembly = Assembly("assembly-test")
+    parts = {}
+    for part in ["part_A", "part-B", "partC", "partD", "partE", "partF"]:
+        mypart = SheetMetal(x_size=2, y_size=2, z_size=2, part_no=part)
+        assembly.add(mypart)
+        parts[part] = mypart
+    # TODO: Rotate and level parts.
+    assembly.save(tmp_path)
+    assembly.render()
+
+    assert len(tuple(tmp_path.glob("*"))) > len(parts.keys()), "Expect a directory per part and files for Assembly"
+    check_files(tmp_path, "assembly-test", ["json", "scad"])
+    for part in parts.keys():
+        part_expected_path = tmp_path / part
+        assert part_expected_path.is_dir(), "Directory for part should exists"
+        check_files(part_expected_path, part, ["json", "scad", "stl"])


### PR DESCRIPTION
The bug: Not passing in path when calling assembly_openscad(). It should be `self.assembler.assembly_openscad(self._base_path)`.
Added a unit test to confirm the issue, rapidly try fixes, and confirm the fix. 

Then there are a few other minor fixes. I try and fix one or two issues reported by `make format` each time I work on a code base.