### PR TITLE
Bump the version to 0.1.0. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 .PHONY: docs
 
 build:
+	find dist -type f | sort | tail -n+5 | xargs rm -f
+	hatch version "$(shell hatch version | cut -d. -f1,2).$(shell date +%s)"
 	hatch build
 
 test:

--- a/src/cycax/__about__.py
+++ b/src/cycax/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present Martin Slabber <martin@tsolo.io>
 #
 # SPDX-License-Identifier: Apache-2.0
-__version__ = "0.0.1"
+__version__ = "0.1.1688381454"


### PR DESCRIPTION
The minor will always be set to the Unix time of the build.

This helped me track down with pip which version was really running. 