### PR TITLE
Martin/part engines

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,8 +4,8 @@ pipeline {
         stage('Setup') {
             steps {
                 sh 'mkdir -p ~/Applications'
-                sh 'wget -c https://files.openscad.org/OpenSCAD-2021.01-x86_64.AppImage -O ~/Applications/OpenSCAD-2021.01-x86_64.AppImage'
-                sh 'wget -c https://github.com/FreeCAD/FreeCAD-Bundle/releases/download/0.20.2/FreeCAD_0.20.2-2022-12-27-conda-Linux-x86_64-py310.AppImage -O ~/Applications/FreeCAD_0.20.2-2022-12-27-conda-Linux-x86_64-py310.AppImage'
+                sh 'wget -c https://files.openscad.org/OpenSCAD-2021.01-x86_64.AppImage -P ~/Applications'
+                sh 'wget -c https://github.com/FreeCAD/FreeCAD-Bundle/releases/download/0.20.2/FreeCAD_0.20.2-2022-12-27-conda-Linux-x86_64-py310.AppImage -P ~/Applications'
                 sh 'chmod a+x ~/Applications/*.AppImage'
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,13 @@
 pipeline {
     agent any
     stages {
+        stage('Setup') {
+            steps {
+                sh 'wget -c https://files.openscad.org/OpenSCAD-2021.01-x86_64.AppImage -O ~/Applications/OpenSCAD-2021.01-x86_64.AppImage'
+                sh 'wget -c https://github.com/FreeCAD/FreeCAD-Bundle/releases/download/0.20.2/FreeCAD_0.20.2-2022-12-27-conda-Linux-x86_64-py310.AppImage -O ~/Applications/FreeCAD_0.20.2-2022-12-27-conda-Linux-x86_64-py310.AppImage'
+                sh 'chmod a+x ~/Applications/*.AppImage'
+            }
+        }
         stage('Build docs') {
             steps {
                 sh 'hatch run docs:build'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@ pipeline {
     stages {
         stage('Setup') {
             steps {
+                sh 'mkdir -p ~/Applications'
                 sh 'wget -c https://files.openscad.org/OpenSCAD-2021.01-x86_64.AppImage -O ~/Applications/OpenSCAD-2021.01-x86_64.AppImage'
                 sh 'wget -c https://github.com/FreeCAD/FreeCAD-Bundle/releases/download/0.20.2/FreeCAD_0.20.2-2022-12-27-conda-Linux-x86_64-py310.AppImage -O ~/Applications/FreeCAD_0.20.2-2022-12-27-conda-Linux-x86_64-py310.AppImage'
                 sh 'chmod a+x ~/Applications/*.AppImage'

--- a/src/cycax/cycad/engine_openscad.py
+++ b/src/cycax/cycad/engine_openscad.py
@@ -201,6 +201,19 @@ class EngineOpenSCAD:
 
         SCAD.close()
 
+    def get_appimage(self) -> Path:
+        paths = ["~/Applications", self._base_path]
+        appimage = None
+        for p in paths:
+            path = Path(p).expanduser()
+            if not path.exists():
+                # There is no such path.
+                logging.error("No path %s", path)
+                break
+            for appimg in path.glob("OpenSCAD*.AppImage"):
+                appimage = appimg
+        return appimage
+
     def render_stl(self, part_name: str = None):
         """
 
@@ -221,8 +234,10 @@ class EngineOpenSCAD:
             msg = f"the part name {part_name} does not map to a scad file at {in_name}."
             raise ValueError(msg)
 
+        app_bin = self.get_appimage()
         logging.info("!!! THIS WILL TAKE SOME TIME, BE PATIENT !!!")
-        result = subprocess.run(["openscad", "-o", out_stl_name, in_name], capture_output=True, text=True)
+        print(app_bin)
+        result = subprocess.run([app_bin, "-o", out_stl_name, in_name], capture_output=True, text=True)
 
         if result.stdout:
             logging.info("OpenSCAD: %s", result.stdout)

--- a/src/cycax/cycad/engine_openscad.py
+++ b/src/cycax/cycad/engine_openscad.py
@@ -211,32 +211,32 @@ class EngineOpenSCAD:
                 logging.error("No path %s", path)
                 break
             for appimg in path.glob("OpenSCAD*.AppImage"):
+                # Very simple implimentation to get tests to pass on CI.
+                # TODO: Sort the Appimages and to get the latest.
                 appimage = appimg
         return appimage
 
     def render_stl(self, part_name: str = None):
-        """
+        """Calls OpenSCAD to create a STL for the part.
 
-        This takes a SCAD object and runs a command through linex that converts it into an stl.
         Depending on the complexity of the object it can take long to compute.
-        It prints out some messages to the terminal so that the impatient user will hopefully wait.(Similar to many windows request.)
+        It prints out some messages to the terminal so that the impatient user will hopefully wait. Similar to many windows request.
 
         Args:
-            part_name : This is the name of the file which will be converted from a scad to a stl.
+            part_name : This is the name of the file which will be converted from a SCAD to a STL.
 
         Raises:
-            ValueError: if incorrect part_name is provided.
+            ValueError: If incorrect part_name is provided.
 
         """
         in_name = "{cwd}/{data}/{data}.scad".format(cwd=self._base_path, data=part_name)
         out_stl_name = "{cwd}/{data}/{data}.stl".format(cwd=self._base_path, data=part_name)
         if not os.path.exists(in_name):
-            msg = f"the part name {part_name} does not map to a scad file at {in_name}."
+            msg = f"The part name {part_name} does not map to a SCAD file at {in_name}."
             raise ValueError(msg)
 
         app_bin = self.get_appimage()
-        logging.info("!!! THIS WILL TAKE SOME TIME, BE PATIENT !!!")
-        print(app_bin)
+        logging.info("!!! THIS WILL TAKE SOME TIME, BE PATIENT !!! using %s", app_bin)
         result = subprocess.run([app_bin, "-o", out_stl_name, in_name], capture_output=True, text=True)
 
         if result.stdout:


### PR DESCRIPTION
This PR adds a step to the Jenkins file to download AppImage binaries we depend on.
wget is used with the -c flag, wget will check if the binary is correct, it will continue a download if interrupted.

The check in OpenSCAD Engine is very simple, that just to get the tests to pass, will make it nicer and share the code between the engines.