### PR TITLE
Update the calling of assembler engine.

### DIFF
--- a/src/cycax/__about__.py
+++ b/src/cycax/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present Martin Slabber <martin@tsolo.io>
 #
 # SPDX-License-Identifier: Apache-2.0
-__version__ = "0.2.1705552309"
+__version__ = "0.2.1705879187"

--- a/src/cycax/cycad/features.py
+++ b/src/cycax/cycad/features.py
@@ -2,9 +2,8 @@ from cycax.cycad.location import Location
 
 
 class Feature(Location):
-    """The Parent class of all features,
+    """The Parent class of all features,"""
 
-    """
     def export(self) -> dict:
         """Create a dictionary holding a representation of the feature.
 
@@ -16,7 +15,7 @@ class Feature(Location):
         """
 
         dict_hole = {}
-        for key in ('name', 'type'):
+        for key in ("name", "type"):
             getattr(self, key)  # Just get the attribute and let Python raise attribute error if it does not exists.
 
         for key, value in vars(self).items():
@@ -24,6 +23,7 @@ class Feature(Location):
                 dict_hole[key] = value
 
         return dict_hole
+
 
 class Holes(Feature):
     """This class will store data on holes. A hole is a cylinder cut into an object.
@@ -45,7 +45,7 @@ class Holes(Feature):
         Location.__init__(self, x, y, z, side)
         self.diameter = diameter
         self.depth = depth
-        self.name  = "hole"
+        self.name = "hole"
         self.type = "cut"
 
 


### PR DESCRIPTION
A light cleanup and refactor of the AssemblyEngine calling. Not quite done.

The main improvement in this update is that assembly.render() will give you the current assembly. No need to call assembly.save() first, part engine might still need save to be called first.
A future update will allow assembly classes to be passed for each type of assembly not just the name, thus a class is pre-configured according to its own style before being used. Then add() is called on the class for each part and the product is created when build() is called.
We will then be able to move engines into their own packages and only install and use what we need when we need it.
This should also simplify the adding of more engines.