### PR TITLE
feat: Added the link location engine.

### DIFF
--- a/src/cycax/cycad/engines/part_locallinklocation.py
+++ b/src/cycax/cycad/engines/part_locallinklocation.py
@@ -1,0 +1,35 @@
+import logging
+import time
+from pathlib import Path
+
+from cycax.cycad.engines.base_part_engine import PartEngine
+from cycax.cycad.engines.utils import check_source_hash
+
+
+class PartEngineLLL(PartEngine):
+    """
+    Use symlinks at a specific location to run Jobs on FreeCAD.
+    """
+
+    def check_part_init(self):
+        """Early hook for part classes to do custom checks."""
+        self.config["freecad_jobs_location"]
+
+    def build(self) -> list:
+        """Create the output files for the part."""
+
+        part_path = self._base_path / self.name
+        timestamp = int(time.time())
+        symlink_part_path = self.config["freecad_jobs_location"] / f"{timestamp}.{self.name}"
+
+        Path(symlink_part_path).symlink_to(part_path)
+
+        for _ in range(29):
+            if symlink_part_path.exists():
+                time.sleep(1)
+            else:
+                break
+
+        _files = []
+
+        return self.file_list(files=_files, engine="OpenSCAD", score=3)


### PR DESCRIPTION
This PR adds the ability to call instances of PartEngine in assembly and not let the assembly engine instantiate the PartEngines. This allow us to configure and control the PartEngine without having to pass in a lot of mechanics to the assembler.

Also adds a POC of sending information to a running FreeCAD, using symlink directories.