### PR TITLE
feat: Only call the part engine once per part.

### DIFF
--- a/src/cycax/cycad/assembly.py
+++ b/src/cycax/cycad/assembly.py
@@ -76,8 +76,8 @@ class Assembly:
 
         engine.set_path(self._base_path)
 
-        completed_parts = []
         for part_engine in part_engines:
+            completed_parts = []
             for part in self.parts.values():
                 if part.part_no not in completed_parts:
                     part_engine.new(part.part_no, self._base_path)

--- a/src/cycax/cycad/assembly_blender.py
+++ b/src/cycax/cycad/assembly_blender.py
@@ -5,8 +5,10 @@ from pathlib import Path
 import bpy
 import matplotlib.colors as mcolors
 
+from cycax.cycad.engines.base_assembly_engine import AssemblyEngine
 
-class AssemblyBlender:
+
+class AssemblyBlender(AssemblyEngine):
     """Assemble the parts into an Blender model.
 
     Args:

--- a/src/cycax/cycad/assembly_openscad.py
+++ b/src/cycax/cycad/assembly_openscad.py
@@ -1,8 +1,10 @@
 import logging
 from pathlib import Path
 
+from cycax.cycad.engines.base_assembly_engine import AssemblyEngine
 
-class AssemblyOpenSCAD:
+
+class AssemblyOpenSCAD(AssemblyEngine):
     """Assemble the parts into an OpenSCAD model.
 
     Attributes:

--- a/src/cycax/cycad/cycad_part.py
+++ b/src/cycax/cycad/cycad_part.py
@@ -12,6 +12,7 @@ from cycax.cycad.engines.simple_2d import Simple2D
 from cycax.cycad.features import Holes, NutCutOut, RectangleCutOut, SphereCutOut
 from cycax.cycad.location import BACK, BOTTOM, FRONT, LEFT, RIGHT, TOP, Location
 from cycax.cycad.slot import Slot
+from cycax.cycad.engines.base_assembly_engine import AssemblyEngine
 
 
 class CycadPart(Location):
@@ -27,6 +28,7 @@ class CycadPart(Location):
         part_no : The unique name that will be given to a type of parts.
         polygon: currently only cube available.
         colour: colour of the part.
+        assembly: The assembly this part is a component of.
 
     """
 
@@ -42,7 +44,7 @@ class CycadPart(Location):
         z_size: float,
         polygon: str,
         colour: str = "orange",
-        assembly=None,
+        assembly: AssemblyEngine = None,
     ):
         super().__init__(x, y, z, side)
         self._name: str = ""
@@ -76,6 +78,8 @@ class CycadPart(Location):
         self._files = {}
         self.definition()
         self.assembly = assembly
+        if assembly:
+            assembly.add(self)
 
     def definition(self):
         """This method will be ovedridden to do a calculation."""

--- a/src/cycax/cycad/cycad_part.py
+++ b/src/cycax/cycad/cycad_part.py
@@ -13,6 +13,8 @@ from cycax.cycad.features import Holes, NutCutOut, RectangleCutOut, SphereCutOut
 from cycax.cycad.location import BACK, BOTTOM, FRONT, LEFT, RIGHT, TOP, Location
 from cycax.cycad.slot import Slot
 
+# from cycax.cycad.assembly import Assembly
+
 
 class CycadPart(Location):
     """Define a Part in CyCAd.
@@ -42,6 +44,7 @@ class CycadPart(Location):
         z_size: float,
         polygon: str,
         colour: str = "orange",
+        assembly=None,
     ):
         super().__init__(x, y, z, side)
         self._name: str = ""
@@ -74,7 +77,7 @@ class CycadPart(Location):
         self.labels: set[str] = set()
         self._files = {}
         self.definition()
-        self.assembly = None
+        self.assembly = assembly
 
     def definition(self):
         """This method will be ovedridden to do a calculation."""

--- a/src/cycax/cycad/cycad_part.py
+++ b/src/cycax/cycad/cycad_part.py
@@ -13,8 +13,6 @@ from cycax.cycad.features import Holes, NutCutOut, RectangleCutOut, SphereCutOut
 from cycax.cycad.location import BACK, BOTTOM, FRONT, LEFT, RIGHT, TOP, Location
 from cycax.cycad.slot import Slot
 
-# from cycax.cycad.assembly import Assembly
-
 
 class CycadPart(Location):
     """Define a Part in CyCAd.


### PR DESCRIPTION
The assembly build method is much faster for assemblies that have multiples of the same part e.g. conn_cubes.
We check if we have built the part and if it has been built do not call build on the part again.

This does not improve the performance of the render method, for now I'm leaving render untouched as a reference implementation while ironing out the build method.