### PR TITLE
Small update to passing in Assembly at part creation.

### DIFF
--- a/src/cycax/cycad/assembly_blender.py
+++ b/src/cycax/cycad/assembly_blender.py
@@ -19,6 +19,10 @@ class AssemblyBlender(AssemblyEngine):
         self.name = name
         self._base_path = Path(".")
         self.parts = {}
+        objs = bpy.data.objects
+        if "Cube" in objs:
+            # Remove the small Cube that is on all new models.
+            objs.remove(objs["Cube"], do_unlink=True)
 
     def _fetch_part(self, part: str):
         """Retrieves the part that will be imported and possitioned.

--- a/src/cycax/cycad/cuboid.py
+++ b/src/cycax/cycad/cuboid.py
@@ -16,7 +16,13 @@ class Cuboid(CycadPart):
     """
 
     def __init__(
-        self, part_no: str, x_size: float, y_size: float, z_size: float, assembly: Assembly, colour: str = "pink"
+        self,
+        part_no: str,
+        x_size: float,
+        y_size: float,
+        z_size: float,
+        assembly: Assembly | None = None,
+        colour: str = "pink",
     ):
         super().__init__(
             x=0,
@@ -42,10 +48,13 @@ class SheetMetal(Cuboid):
         y_size : The size of y.
         z_size : The size of z.
         part_no : The unique name that will be given to a type of parts.
+        assembly: The assembly the part belongs to.
     """
 
-    def __init__(self, part_no: str, x_size: float, y_size: float, z_size: float = 2.0):
-        super().__init__(part_no=part_no, x_size=x_size, y_size=y_size, z_size=z_size, colour="grey")
+    def __init__(
+        self, part_no: str, x_size: float, y_size: float, z_size: float = 2.0, assembly: Assembly | None = None
+    ):
+        super().__init__(part_no=part_no, x_size=x_size, y_size=y_size, z_size=z_size, colour="grey", assembly=assembly)
 
 
 class Print3D(Cuboid):
@@ -57,7 +66,8 @@ class Print3D(Cuboid):
         y_size : The size of y.
         z_size : The size of z.
         part_no : The unique name that will be given to a type of parts.
+        assembly: The assembly the part belongs to.
     """
 
-    def __init__(self, part_no: str, x_size: float, y_size: float, z_size: float):
-        super().__init__(part_no=part_no, x_size=x_size, y_size=y_size, z_size=z_size, colour="red")
+    def __init__(self, part_no: str, x_size: float, y_size: float, z_size: float, assembly: Assembly | None = None):
+        super().__init__(part_no=part_no, x_size=x_size, y_size=y_size, z_size=z_size, colour="red", assembly=assembly)

--- a/src/cycax/cycad/engines/part_server.py
+++ b/src/cycax/cycad/engines/part_server.py
@@ -65,6 +65,8 @@ class PartEngineServer(PartEngine):
         """Create the output files for the part."""
 
         logging.error("PartServer.build(%s)", part.part_no)
+        if part.part_no not in self.jobs:
+            self.create(part)
         logging.error(self.jobs[part.part_no])
         job_id = self.jobs[part.part_no]["id"]
         job = self.server_get_job(job_id)

--- a/src/freecad/cycax_part_freecad.py
+++ b/src/freecad/cycax_part_freecad.py
@@ -531,7 +531,7 @@ def get_next_job_path(jobs_path) -> dict:
     return None
 
 
-def control_file(jobs_path: Path, name: str, start=False) -> bool:
+def control_file(jobs_path: Path, name: str, *, start=False) -> bool:
     if name in ("quit", "finnish"):
         quit_file = jobs_path / f".{name}"
     else:


### PR DESCRIPTION
This is a small PR with three fixes in:

Remove the start cube from blender designs. There was always an small cube on all blender pictures. This fix removes that cube.

Link the assembly to the part when part is created. Normally a part is linked to an assembly after creation this change is just a shorthand that allow passing in the assembly when the part is defined.

On the previous PR create before build on PartEngine were introduced. But older projects had no knowledge of create, in the PartEngineServer where this is essential, we check if create were called and call it if not yet called, this has a performance impact but not on Assemblies thus it is ok.