### PR TITLE
Add counterbore on top and bottom sides.

### DIFF
--- a/src/cycax/cycad/cycad_part.py
+++ b/src/cycax/cycad/cycad_part.py
@@ -111,6 +111,66 @@ class CycadPart(Location):
         for label in label_names:
             self.labels.add(str(label).lower())
 
+    def make_countersinc(self, side: str, diameter: float, angle: float = 90):
+        """Countersinc all holes on the side.
+
+        This includes holes drilled from this and opposite side.
+
+        """
+        # A Counter drill with no bole.
+        self.make_counterdrill(side=side, diameter=diameter, depth=0, angle=angle)
+
+    def make_counterbore(self, side: str, diameter: float, depth: float):
+        """Counterbore all holes on the side.
+
+        This includes holes drilled from this and opposite side.
+
+        """
+        side_obj = self.get_side(side)
+        sides = (side, side_obj.opposite.name)
+        new_holes = []
+        for feature in self.features:
+            if feature.name not in ("hole",):
+                continue
+            use = feature.side in sides
+            logging.error("make_counterbore side=%s, %s %s", side, feature, use)
+            if feature.side == side:
+                _hole = Holes(side=feature.side, x=feature.x, y=feature.y, z=feature.z, diameter=diameter, depth=depth)
+                new_holes.append(_hole)
+            elif feature.side == side_obj.opposite.name:
+                if side == BOTTOM:
+                    z = depth
+                else:
+                    z = self.z_size - depth
+                _hole = Holes(side=feature.side, x=feature.x, y=feature.y, z=z, diameter=diameter, depth=depth)
+                new_holes.append(_hole)
+            # if feature.side == side:
+            #     _hole = Holes(side=side,
+            #             x=feature.x,
+            #             # y=feature.y,
+            #             y=self.y_size-feature.y,
+            #             z=feature.z,
+            #             diameter=diameter, depth=depth)
+            #     new_holes.append(_hole)
+            # elif feature.side == side_obj.opposite.name:
+            #     _hole = Holes(side=side,
+            #             x=feature.x,
+            #             y=self.y_size-feature.y,
+            #             z=self.z_size,
+            #             diameter=diameter,
+            #             depth=depth)
+            #     new_holes.append(_hole)
+        self.features.extend(new_holes)
+
+    def make_counterdrill(self, side: str, diameter: float, depth: float, angle: float = 90):
+        """Counter drill is a combination of counterbore and countersinc.
+
+        A counterbore hole that was countersunc.
+        """
+
+        # TODO: Require cone shape cut.
+        raise NotImplementedError("The adding of counterdrill to a side has not been implemented.")
+
     def make_hole(
         self,
         x: float,

--- a/src/cycax/cycad/cycad_part.py
+++ b/src/cycax/cycad/cycad_part.py
@@ -127,13 +127,10 @@ class CycadPart(Location):
 
         """
         side_obj = self.get_side(side)
-        sides = (side, side_obj.opposite.name)
         new_holes = []
         for feature in self.features:
             if feature.name not in ("hole",):
                 continue
-            use = feature.side in sides
-            logging.error("make_counterbore side=%s, %s %s", side, feature, use)
             if feature.side == side:
                 _hole = Holes(side=feature.side, x=feature.x, y=feature.y, z=feature.z, diameter=diameter, depth=depth)
                 new_holes.append(_hole)

--- a/src/cycax/cycad/cycad_part.py
+++ b/src/cycax/cycad/cycad_part.py
@@ -144,22 +144,6 @@ class CycadPart(Location):
                     z = self.z_size - depth
                 _hole = Holes(side=feature.side, x=feature.x, y=feature.y, z=z, diameter=diameter, depth=depth)
                 new_holes.append(_hole)
-            # if feature.side == side:
-            #     _hole = Holes(side=side,
-            #             x=feature.x,
-            #             # y=feature.y,
-            #             y=self.y_size-feature.y,
-            #             z=feature.z,
-            #             diameter=diameter, depth=depth)
-            #     new_holes.append(_hole)
-            # elif feature.side == side_obj.opposite.name:
-            #     _hole = Holes(side=side,
-            #             x=feature.x,
-            #             y=self.y_size-feature.y,
-            #             z=self.z_size,
-            #             diameter=diameter,
-            #             depth=depth)
-            #     new_holes.append(_hole)
         self.features.extend(new_holes)
 
     def make_counterdrill(self, side: str, diameter: float, depth: float, angle: float = 90):


### PR DESCRIPTION
This is a long awaited feature. Maybe not implemented in the smartest way, I think I need some help.

For now it will counter bore all holes on a side to a given depth and diameter. This is not quite right since we could have big holes and small holes. We need to figure out how to present this and give choice - for this reason it was only added to part and not sides. Thus we know the part interface will change and once that change is made we can do the side.

In short: This is not implemented `part.top.counterbore(...)` and will be the objective.

It would also be nice to add a counterbore method and init settings on the Hole class. On creation and post. This PR does not use the hole feature in such an intelligent manner.

Countersunc and counterdrill was not implemented since we are missing a code primitive.
