### PR TITLE
feat: Only download new artifacts.

### DIFF
--- a/src/cycax/parts/fan.py
+++ b/src/cycax/parts/fan.py
@@ -124,7 +124,7 @@ class Fan80x80(Fan):
             internal=internal,
             side_pad=side_pad,
             hole_depth=None,
-            hole_diameter=3.0,
+            hole_diameter=3.2,
         )
 
 


### PR DESCRIPTION
This PR makes the Cycax Server client engine only download files (artifacts) if they don't exist or when the JOB ID of the part changes. JOB ID is the SHA of the JSON that define the part, thus JOB ID changes when the part changes.
 
This speeds up Cycax a little bit on a fast network but has a big impact when the connection is a bit slow.