### PR TITLE
Fix: Fan mounting holes.

### DIFF
--- a/src/cycax/parts/fan.py
+++ b/src/cycax/parts/fan.py
@@ -124,7 +124,7 @@ class Fan80x80(Fan):
             internal=internal,
             side_pad=side_pad,
             hole_depth=None,
-            hole_diameter=3.0,
+            hole_diameter=3.2,
         )
 
 


### PR DESCRIPTION
The mounting holes are to small. We will use 3mm bolts so we should cut the holes a bit bigger. Tested 3.2mm holes and they work well.