### PR TITLE
Fix imports and run in parallel

### DIFF
--- a/src/cycax/cycad/assembly.py
+++ b/src/cycax/cycad/assembly.py
@@ -139,8 +139,6 @@ class Assembly:
             for part in self.parts.values():
                 if part.part_no not in unique_parts:
                     unique_parts[part.part_no] = part
-                    # for part_engine in part_engines:
-                    #     part_engine.create(part)
                 else:
                     logging.warning("The part %s is already processed", part.part_no)
 

--- a/src/cycax/cycad/cuboid.py
+++ b/src/cycax/cycad/cuboid.py
@@ -4,6 +4,7 @@
 
 from cycax.cycad.assembly import Assembly
 from cycax.cycad.cycad_part import CycadPart
+from cycax.cycad.location import BOTTOM
 
 
 class Cuboid(CycadPart):
@@ -29,10 +30,10 @@ class Cuboid(CycadPart):
         colour: str = "pink",
     ):
         super().__init__(
-            x=0,
-            y=0,
-            z=0,
-            side=None,
+            x=0.0,
+            y=0.0,
+            z=0.0,
+            side=BOTTOM,
             part_no=part_no,
             x_size=x_size,
             y_size=y_size,


### PR DESCRIPTION
This PR addresses two issues.
There is a circular import that I could not work around thus we used AssemblyEngine where we should have used Assembly, I fixed this by using annotations from typing.
The second is an improvement to try and get the Jobs to run more parallel but its not hugely better.