### PR TITLE
Martin/cylinder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,14 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["httpx", "tenacity", "matplotlib", "pytest", "build123d"]
+dependencies = [
+    "httpx",
+    "tenacity",
+    "matplotlib",
+    "pytest",
+    "build123d",
+    "numpy-stl",
+]
 
 [project.urls]
 Documentation = "https://github.com/tsolo-dev/cycax#readme"

--- a/src/cycax/cycad/__init__.py
+++ b/src/cycax/cycad/__init__.py
@@ -3,6 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from cycax.cycad.assembly import Assembly  # noqa: F401
-from cycax.cycad.cuboid import Cuboid, Print3D, SheetMetal  # noqa: F401
+from cycax.cycad.cuboid import Cuboid, Cylinder, Print3D, SheetMetal  # noqa: F401
 from cycax.cycad.cycad_part import CycadPart  # noqa: F401
 from cycax.cycad.cycad_side import BackSide, BottomSide, FrontSide, LeftSide, RightSide, TopSide  # noqa: F401

--- a/src/cycax/cycad/cuboid.py
+++ b/src/cycax/cycad/cuboid.py
@@ -6,10 +6,45 @@ from cycax.cycad.assembly import Assembly
 from cycax.cycad.cycad_part import CycadPart
 from cycax.cycad.location import BOTTOM
 
+# TODO(MJ): Rename this file.
+
+
+class Cylinder(CycadPart):
+    """
+    This method will initialize a Cylinder.
+    """
+
+    def __init__(
+        self,
+        part_no: str,
+        diameter: float,
+        height: float,
+        assembly: Assembly | None = None,
+        colour: str = "pink",
+    ):
+        self.x_center = diameter / 2
+        self.y_center = diameter / 2
+        self.z_center = height / 2
+        self.radius = diameter / 2
+        self.diameter = diameter
+        super().__init__(
+            x=0.0,  # Origin is outside of the cylinder.
+            y=0.0,  # Origin is outside of the cylinder.
+            z=0.0,  # Origin is outside of the cylinder.
+            side=BOTTOM,
+            part_no=part_no,
+            x_size=diameter,
+            y_size=diameter,
+            z_size=height,
+            assembly=assembly,
+            colour=colour,
+            polygon="cylinder",
+        )  # initializes the cylinder to (0,0,0)
+
 
 class Cuboid(CycadPart):
     """
-    This method will initialize a Cuboid at the desired location.
+    This method will initialize a Cuboid of a specific size.
 
     Args:
         x_size : The size of x.

--- a/src/cycax/cycad/cycad_part.py
+++ b/src/cycax/cycad/cycad_part.py
@@ -390,9 +390,9 @@ class CycadPart(Location):
         """This method will be used for inserting the hole into an object.
 
         Args:
-            hole: hole to be inserted.
+            feature: The feature transferred from the leveled part.
         """
-        # TODO: Maybe rename no subtract feature.
+        # TODO: Maybe rename to subtract_feature.
         # NOTE: Issues exist when subtracting rectangles from back of part.
         if self.position[0] != 0.0:
             feature.move(x=-self.position[0])

--- a/src/cycax/cycad/engines/part_build123d.py
+++ b/src/cycax/cycad/engines/part_build123d.py
@@ -21,6 +21,21 @@ class PartEngineBuild123d(PartEngine):
         self.jobs = {}
         super().__init__(name, path, config)
 
+    def _decode_cylinder(self, feature_spec: dict) -> build123d.objects_part.Box:
+        """
+        This method creates a Cylinder object in Build123d.
+
+        Args:
+            feature_spec: The details about the cylinder.
+
+        """
+        radius = feature_spec["x_size"] / 2
+        height = feature_spec["z_size"]
+        feature = build123d.Cylinder(radius=radius, height=height)
+        # TODO: Support the different orientations
+        feature = build123d.Pos(radius, radius, height / 2) * feature
+        return feature
+
     def _decode_cube(self, feature_spec: dict) -> build123d.objects_part.Box:
         """
         This method will return the string that will have the Build123d for a cube.
@@ -231,6 +246,8 @@ class PartEngineBuild123d(PartEngine):
                     feature = self._decode_nut(action)
                 case "beveled_edge":
                     feature = self._decode_beveled_edge(action)
+                case "cylinder":
+                    feature = self._decode_cylinder(action)
                 case _:
                     msg = f"Unknown feature type: {action['name']}"
                     raise ValueError(msg)

--- a/src/cycax/cycad/engines/part_freecad.py
+++ b/src/cycax/cycad/engines/part_freecad.py
@@ -15,6 +15,8 @@ from cycax.cycad.location import TOP
 
 class PartEngineFreeCAD(PartEngine):
     def build(self, part) -> dict:  # noqa: ARG002 Unused argument
+        # self._base_path = part._base_path
+        # self.name = part.part_no
         fcstd_file = self._base_path / self.name / f"{self.name}.FCStd"
         if check_source_hash(self._json_file, fcstd_file):
             app_bin = self.get_appimage("FreeCAD")
@@ -25,6 +27,8 @@ class PartEngineFreeCAD(PartEngine):
             out_formats_set = set()
             for file_format in self.config.get("out_formats", []):
                 out_formats_set.add(":".join(file_format[:2]))
+            if not out_formats_set:
+                out_formats_set.add("STL")
 
             environment = dict(os.environ)
             environment.update(

--- a/src/examples/gear_factory.py
+++ b/src/examples/gear_factory.py
@@ -9,37 +9,43 @@ Note: It makes a gear like things for now.
 
 import math
 
-from cycax.cycad import Print3D
+from cycax.cycad import Cylinder
 from cycax.cycad.engines.part_build123d import PartEngineBuild123d
 
 
-class Gear(Print3D):
+class Gear(Cylinder):
     """Define a gear.
 
     Note: It makes a gear like things for now.
 
     """
 
-    def __init__(self, outer_diameter=0):
-        name = f"Gear-{outer_diameter}"
-        super().__init__(part_no=name, x_size=11, y_size=11, z_size=2)
+    def __init__(self, diameter: float, teath: int = 12):
+        name = f"Gear-{diameter}-{teath}"
+        self.teath = teath
+        if diameter < 10:  # noqa PLR2004 Magic value used
+            msg = "Diameter must be greater than 10"
+            raise ValueError(msg)
+        if teath < 6:  # noqa PLR2004 Magic value used
+            msg = "Teeth must be greater than 6"
+            raise ValueError(msg)
+        super().__init__(part_no=name, diameter=diameter, height=3)
 
     def definition(self):
         """Calculate the gear."""
-        cx = self.x_size / 2
-        cy = self.y_size / 2
-        radius = self.x_size / 2 - 1
-        self.top.hole(pos=(cx, cy), diameter=2)
-        self.top.box(pos=(cx - 0.5, cy), length=1, width=1.2)
-        angle = (math.pi * 2) / 12
-        for n in range(1, 13):
-            pos = (cx + math.cos(angle * n) * radius, cy + math.sin(angle * n) * radius)
-            self.top.hole(pos=pos, diameter=1)
-        self.top.hole(pos=(cx, cy), diameter=2 * radius - 1.5, depth=0.5)
+        self.bottom.hole(pos=(self.x_center, self.y_center), diameter=2)
+        self.top.box(pos=(self.x_center - 0.5, self.y_center), length=1, width=1.2)
+        teath_diameter = math.pi * self.diameter / self.teath
+        angle = (math.pi * 2) / self.teath
+        radius = self.diameter / 2
+        for n in range(1, self.teath + 1):
+            pos = (self.x_center + math.cos(angle * n) * radius, self.y_center + math.sin(angle * n) * radius)
+            self.top.hole(pos=pos, diameter=teath_diameter)
+        self.top.hole(pos=(self.x_center, self.y_center), diameter=2 * radius - teath_diameter - 2, depth=0.5)
 
 
 if __name__ == "__main__":
-    gear = Gear()
+    gear = Gear(diameter=10, teath=6)
     gear.save("./build")
     cycax_server = PartEngineBuild123d()
     cycax_server.build(gear)

--- a/tests/test_cylinder.py
+++ b/tests/test_cylinder.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2025 Tsolo.io
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+from cycax.cycad import Cylinder
+from cycax.cycad.engines.part_build123d import PartEngineBuild123d
+from cycax.cycad.engines.part_freecad import PartEngineFreeCAD
+from tests.shared import stl_compare, stl_compare_models
+
+
+def sphere_cube(tmp_path: Path):
+    cylinder = Cylinder(diameter=10, height=10, part_no="test_cylinder")
+
+    cylinder.save(tmp_path)
+    cylinder.build(PartEngineBuild123d())
+    stl = tmp_path / "test_cylinder" / "test_cylinder.stl"
+    build123d_stl = stl.with_name("test_cylinder_build123d.stl")
+    stl.rename(build123d_stl)
+    cylinder.build(PartEngineFreeCAD(name=cylinder.part_no, path=tmp_path))
+    # Read Build123d Mesh
+    stl_compare_models(build123d_stl, stl)
+
+
+def test_sphere(tmp_path: Path):
+    print(tmp_path)
+    sphere_cube(tmp_path)

--- a/tests/test_part_box_subtract.py
+++ b/tests/test_part_box_subtract.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2025 Tsolo.io
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+from cycax.cycad import Assembly, Cuboid, SheetMetal
+from cycax.cycad.engines.assembly_build123d import AssemblyBuild123d
+from cycax.cycad.engines.part_build123d import PartEngineBuild123d
+
+
+class Socket(Cuboid):
+    """A simple part with a rectangle cutout and a matching rectangle external subtract.
+
+    A small hole and external subtract of this hole is also made to check alignment.
+    """
+    def __init__(self):
+        super().__init__(part_no="socket", x_size=34.0, y_size=24.0, z_size=20.0)
+
+    def definition(self):
+        """Calculate the connect cube."""
+        pos = (2, 2)
+        length = self.x_size - 4
+        width = self.z_size - 4
+        self.back.box(pos=pos, length=length, width=width, depth=15)
+        self.back.box(
+            pos=pos,
+            length=length,
+            width=width,
+            external_subtract=True,
+        )
+        self.back.hole(pos=pos, diameter=1)
+        self.back.hole(pos=pos, diameter=1, external_subtract=True)
+
+
+def make_plate_with_connect_cubes(back: bool = True) -> Assembly:
+    """Makes a plate with a socket that has a rectangle cutout.
+
+    Returns:
+        The assembly that was created with plate and socket.
+    """
+    assembly = Assembly("test")
+    base = SheetMetal(z_size=2.0, x_size=100, y_size=200, part_no="base")
+    assembly.add(base)
+    base.rotate("yz")
+
+    psocket = Socket()
+    assembly.add(psocket)
+    if back:
+        psocket.rotate("xx")
+        psocket.level(front=base.back, top=base.top, left=base.left)
+        psocket.move(z=-5, x=5)
+        psocket.level(front=base.back, subtract=True)
+    else:
+        psocket.level(back=base.front, top=base.top, right=base.right)
+        psocket.move(z=-5, x=-5)
+        psocket.level(back=base.front, subtract=True)
+
+    return assembly
+
+
+def test_subtract_side():
+    """This test creates a plate with a socket that has a rectangle cutout and a hole.
+
+    A check is made to ensure that the hole and the rectangle cutout are at the same locations.
+    This test is a simplification of a real life problem.
+    """
+
+    for flip in (True, False):
+        assembly = make_plate_with_connect_cubes(back=flip)
+        # Help with debugging
+        save_path = Path("/tmp/test-subtract/")
+        save_path.mkdir(parents=True, exist_ok=True)
+        assembly.save(save_path)
+        assembly.build(engine=AssemblyBuild123d(assembly.name), part_engines=[PartEngineBuild123d()])
+
+        base = assembly.get_part("base_1").export()
+        compare = {}
+        print(base)
+        for feature in base["features"]:
+            if feature["type"] == "cut":
+                compare[feature["name"]] = feature
+        assert compare["hole"]["x"] == compare["cube"]["x"]
+        assert compare["hole"]["y"] == compare["cube"]["y"]
+        assert compare["hole"]["z"] == compare["cube"]["z"]

--- a/tests/test_part_box_subtract.py
+++ b/tests/test_part_box_subtract.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from cycax.cycad import Assembly, Cuboid, SheetMetal
 from cycax.cycad.engines.assembly_build123d import AssemblyBuild123d
 from cycax.cycad.engines.part_build123d import PartEngineBuild123d
-
 from cycax.cycad.location import BACK, BOTTOM, FRONT, LEFT, RIGHT, SIDES, TOP
+
 
 class Socket(Cuboid):
     """A simple part with a rectangle cutout and a matching rectangle external subtract.
@@ -17,6 +17,7 @@ class Socket(Cuboid):
     The one hole has a diameter of 1mm and the other a diameter of 2mm.
     The socket is rotated so that the 1mm hole should be the origin of the cut square.
     """
+
     def __init__(self):
         super().__init__(part_no="socket", x_size=34.0, y_size=24.0, z_size=20.0)
 
@@ -36,11 +37,11 @@ class Socket(Cuboid):
         self.back.hole(pos=pos, diameter=1)
         self.back.hole(pos=pos, diameter=1, external_subtract=True)
         # The 2mm hole is for visual reference only, when debugging the test.
-        self.back.hole(pos=(pos[0]+length, pos[1]+width), diameter=2)
-        self.back.hole(pos=(pos[0]+length, pos[1]+width), diameter=2, external_subtract=True)
+        self.back.hole(pos=(pos[0] + length, pos[1] + width), diameter=2)
+        self.back.hole(pos=(pos[0] + length, pos[1] + width), diameter=2, external_subtract=True)
         # The 3mm hole is to check the center of the cutout. This will all us to determine the orientation.
-        self.back.hole(pos=(pos[0]+length/2, pos[1]+width/2), diameter=3)
-        self.back.hole(pos=(pos[0]+length/2, pos[1]+width/2), diameter=3, external_subtract=True)
+        self.back.hole(pos=(pos[0] + length / 2, pos[1] + width / 2), diameter=3)
+        self.back.hole(pos=(pos[0] + length / 2, pos[1] + width / 2), diameter=3, external_subtract=True)
 
 
 def make_plate_with_socket(side: str) -> Assembly:
@@ -99,13 +100,13 @@ def test_subtract_side():
             print(_side, feature)
             if feature["type"] == "cut":
                 if feature["name"] == "hole":
-                    name = f"{feature["name"]}{feature['diameter']}"
+                    name = f"{feature['name']}{feature['diameter']}"
                 else:
                     name = feature["name"]
                 compare[name] = feature
         assert compare["hole1"]["x"] == compare["cube"]["x"]
         assert compare["hole1"]["y"] == compare["cube"]["y"]
         assert compare["hole1"]["z"] == compare["cube"]["z"]
-        assert compare["hole1"]["x"] == (compare["cube"]["x"] +compare["cube"]["x_size"]/2)
-        assert compare["hole1"]["y"] == (compare["cube"]["y"] +compare["cube"]["y_size"]/2)
-        assert compare["hole1"]["z"] == (compare["cube"]["z"] +compare["cube"]["z_size"]/2)
+        assert compare["hole1"]["x"] == (compare["cube"]["x"] + compare["cube"]["x_size"] / 2)
+        assert compare["hole1"]["y"] == (compare["cube"]["y"] + compare["cube"]["y_size"] / 2)
+        assert compare["hole1"]["z"] == (compare["cube"]["z"] + compare["cube"]["z_size"] / 2)

--- a/tests/test_part_box_subtract.py
+++ b/tests/test_part_box_subtract.py
@@ -8,11 +8,14 @@ from cycax.cycad import Assembly, Cuboid, SheetMetal
 from cycax.cycad.engines.assembly_build123d import AssemblyBuild123d
 from cycax.cycad.engines.part_build123d import PartEngineBuild123d
 
+from cycax.cycad.location import BACK, BOTTOM, FRONT, LEFT, RIGHT, SIDES, TOP
 
 class Socket(Cuboid):
     """A simple part with a rectangle cutout and a matching rectangle external subtract.
 
-    A small hole and external subtract of this hole is also made to check alignment.
+    A small holes and external subtract of the holes are made to check alignment.
+    The one hole has a diameter of 1mm and the other a diameter of 2mm.
+    The socket is rotated so that the 1mm hole should be the origin of the cut square.
     """
     def __init__(self):
         super().__init__(part_no="socket", x_size=34.0, y_size=24.0, z_size=20.0)
@@ -29,11 +32,18 @@ class Socket(Cuboid):
             width=width,
             external_subtract=True,
         )
+        # For the test, rotate the part so that the 1mm hole is the origin of the cut square.
         self.back.hole(pos=pos, diameter=1)
         self.back.hole(pos=pos, diameter=1, external_subtract=True)
+        # The 2mm hole is for visual reference only, when debugging the test.
+        self.back.hole(pos=(pos[0]+length, pos[1]+width), diameter=2)
+        self.back.hole(pos=(pos[0]+length, pos[1]+width), diameter=2, external_subtract=True)
+        # The 3mm hole is to check the center of the cutout. This will all us to determine the orientation.
+        self.back.hole(pos=(pos[0]+length/2, pos[1]+width/2), diameter=3)
+        self.back.hole(pos=(pos[0]+length/2, pos[1]+width/2), diameter=3, external_subtract=True)
 
 
-def make_plate_with_connect_cubes(back: bool = True) -> Assembly:
+def make_plate_with_socket(side: str) -> Assembly:
     """Makes a plate with a socket that has a rectangle cutout.
 
     Returns:
@@ -42,19 +52,25 @@ def make_plate_with_connect_cubes(back: bool = True) -> Assembly:
     assembly = Assembly("test")
     base = SheetMetal(z_size=2.0, x_size=100, y_size=200, part_no="base")
     assembly.add(base)
-    base.rotate("yz")
-
     psocket = Socket()
     assembly.add(psocket)
-    if back:
+
+    if side == BACK:
+        base.rotate("yz")
         psocket.rotate("xx")
         psocket.level(front=base.back, top=base.top, left=base.left)
         psocket.move(z=-5, x=5)
         psocket.level(front=base.back, subtract=True)
-    else:
+    elif side == FRONT:
+        base.rotate("yz")
         psocket.level(back=base.front, top=base.top, right=base.right)
         psocket.move(z=-5, x=-5)
         psocket.level(back=base.front, subtract=True)
+    elif side == TOP:
+        psocket.rotate("xxxzz")
+        psocket.level(bottom=base.top, front=base.front, right=base.right)
+        psocket.move(y=5, x=-5)
+        psocket.level(bottom=base.top, subtract=True)
 
     return assembly
 
@@ -66,20 +82,30 @@ def test_subtract_side():
     This test is a simplification of a real life problem.
     """
 
-    for flip in (True, False):
-        assembly = make_plate_with_connect_cubes(back=flip)
+    assembled_side = {}
+    for side in (TOP, BACK, FRONT):
+        assembly = make_plate_with_socket(side=side)
         # Help with debugging
-        save_path = Path("/tmp/test-subtract/")
+        save_path = Path(f"/tmp/test-subtract/{side}")
         save_path.mkdir(parents=True, exist_ok=True)
         assembly.save(save_path)
         assembly.build(engine=AssemblyBuild123d(assembly.name), part_engines=[PartEngineBuild123d()])
+        assembled_side[side] = assembly
 
+    for _side, assembly in assembled_side.items():
         base = assembly.get_part("base_1").export()
         compare = {}
-        print(base)
         for feature in base["features"]:
+            print(_side, feature)
             if feature["type"] == "cut":
-                compare[feature["name"]] = feature
-        assert compare["hole"]["x"] == compare["cube"]["x"]
-        assert compare["hole"]["y"] == compare["cube"]["y"]
-        assert compare["hole"]["z"] == compare["cube"]["z"]
+                if feature["name"] == "hole":
+                    name = f"{feature["name"]}{feature['diameter']}"
+                else:
+                    name = feature["name"]
+                compare[name] = feature
+        assert compare["hole1"]["x"] == compare["cube"]["x"]
+        assert compare["hole1"]["y"] == compare["cube"]["y"]
+        assert compare["hole1"]["z"] == compare["cube"]["z"]
+        assert compare["hole1"]["x"] == (compare["cube"]["x"] +compare["cube"]["x_size"]/2)
+        assert compare["hole1"]["y"] == (compare["cube"]["y"] +compare["cube"]["y_size"]/2)
+        assert compare["hole1"]["z"] == (compare["cube"]["z"] +compare["cube"]["z_size"]/2)


### PR DESCRIPTION
This PR allow use to start a shape as a Cylinder. 

Some notes and/or todo's for future:

- OpenSCAD not yet implemented.
- FreeCAD worker, runs in a different process and accepts tasks via the CyCAx server, does not yet support Cylinders.
- FreeCAD code could use the already existing hole, but I could not immediately figure it out.
- Cylinder up right (along z axis) is the only orientation. Would like to have vertical (along z-axis) and horizontal (along the x-axis) options.
- level by center or align would be nice.

Needed for Ironhive plumbing design work, need to draw in pipes and flanges.