### PR TITLE
feat: Added a level to assembly similar to level on Part.

### DIFF
--- a/src/cycax/cycad/assembly.py
+++ b/src/cycax/cycad/assembly.py
@@ -5,7 +5,7 @@
 import json
 import logging
 import os
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 
@@ -259,30 +259,68 @@ class Assembly:
             center_x = min(part.center[0], center_x)
             center_y = min(part.center[1], center_y)
             center_z = min(part.center[2], center_z)
+        coordinate = namedtuple("Coordinate", ["x", "y", "z"])
+        return coordinate(x=center_x, y=center_y, z=center_z)
 
-        return (center_x, center_y, center_z)
+    def move(self, x: float | None = None, y: float | None = None, z: float | None = None):
+        """This method will be used for moving the assembly.
 
-    def at(self, x: float | None = None, y: float | None = None, z: float | None = None):
+        Args:
+            x: the amount the assembly should be moved by along the x axis.
+            y: the amount the assembly should be moved by along the y axis.
+            z: the amount the assembly should be moved by along the z axis
+        """
+
+        for part in self.parts.values():
+            part.move(x=x, y=y, z=z)
+
+    def at(
+        self,
+        min_x: float | None = None,
+        min_y: float | None = None,
+        min_z: float | None = None,
+        center_x: float | None = None,
+        center_y: float | None = None,
+        center_z: float | None = None,
+    ):
         """Place parts in the assembly at the exact provided coordinates.
 
         Args:
-            x: The value to which x needs to be moved to on the axis.
-            y: The value to which y needs to be moved to on the axis.
-            z: The value to which z needs to be moved to on the axis.
+            min_x: New position of the assemblies closest point to the origin on the x-axis.
+            min_y: New position of the assemblies closest point to the origin on the y-axis.
+            min_z: New position of the assemblies closest point to the origin on the z-axis.
+            center_x: New position of the assemblies center on the x-axis.
+            center_y: New position of the assemblies center on the y-axis.
+            center_z: New position of the assemblies center on the z-axis.
         """
-        if x is not None:
-            x_move = x - self.bounding_box[LEFT]
-        if y is not None:
-            y_move = y - self.bounding_box[FRONT]
-        if z is not None:
-            z_move = z - self.bounding_box[BOTTOM]
+        if min_x and center_x:
+            raise ValueError("Cannot specify both min_x and center_x")
+        if min_y and center_y:
+            raise ValueError("Cannot specify both min_y and center_y")
+        if min_z and center_z:
+            raise ValueError("Cannot specify both min_z and center_z")
+
+        x_move, y_move, z_move = None, None, None
+
+        if min_x is not None:
+            x_move = min_x - self.bounding_box[LEFT]
+        if min_y is not None:
+            y_move = min_y - self.bounding_box[FRONT]
+        if min_z is not None:
+            z_move = min_z - self.bounding_box[BOTTOM]
+        if center_x is not None:
+            x_move = center_x - self.bounding_box[LEFT] / 2
+        if center_y is not None:
+            y_move = center_y - self.bounding_box[FRONT] / 2
+        if center_z is not None:
+            z_move = center_z - self.bounding_box[BOTTOM] / 2
 
         for part in self.parts.values():
-            if x is not None:
+            if x_move is not None:
                 part.at(x=x_move + part.position[0])
-            if y is not None:
+            if y_move is not None:
                 part.at(y=y_move + part.position[1])
-            if z is not None:
+            if z_move is not None:
                 part.at(z=z_move + part.position[2])
 
     def add(self, part, suggested_name: str | None = None, *, external_subtract: bool = False):
@@ -495,8 +533,9 @@ class Assembly:
             Combined Assembly formed from all the assemblies in the list of Assemblies.
         """
         total_parts = {}
-        for assembly in self.assemblies:
-            total_parts.update(assembly.parts)
+        for n, assembly in enumerate(self.assemblies):
+            for part_name, part in assembly.parts.items():
+                total_parts[f"assembly_{n}_{part_name}"] = part
         total_parts.update(self.parts)
         if new_name:
             assembly_out = Assembly(name=new_name)

--- a/src/cycax/cycad/assembly_side.py
+++ b/src/cycax/cycad/assembly_side.py
@@ -68,20 +68,20 @@ class AssemblySide:
         to_here = assembly2_bounding_box[assembly2_side]
 
         if assembly1_side == BOTTOM:
-            assembly1.at(z=to_here)
+            assembly1.at(min_z=to_here)
         elif assembly1_side == TOP:
             z_size = assembly1_bounding_box[TOP] - assembly1_bounding_box[BOTTOM]
-            assembly1.at(z=to_here - z_size)
+            assembly1.at(min_z=to_here - z_size)
         elif assembly1_side == LEFT:
-            assembly1.at(x=to_here)
+            assembly1.at(min_x=to_here)
         elif assembly1_side == RIGHT:
             x_size = assembly1_bounding_box[RIGHT] - assembly1_bounding_box[LEFT]
-            assembly1.at(x=to_here - x_size)
+            assembly1.at(min_x=to_here - x_size)
         elif assembly1_side == FRONT:
-            assembly1.at(y=to_here)
+            assembly1.at(min_y=to_here)
         elif assembly1_side == BACK:
             y_size = assembly1_bounding_box[BACK] - assembly1_bounding_box[FRONT]
-            assembly1.at(y=to_here - y_size)
+            assembly1.at(min_y=to_here - y_size)
         else:
             msg = f"Side: {assembly1_side} is not one of {SIDES}."
             raise ValueError(msg)

--- a/src/cycax/cycad/cycad_part.py
+++ b/src/cycax/cycad/cycad_part.py
@@ -8,6 +8,7 @@ import copy
 import json
 import logging
 import warnings
+from collections import namedtuple
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -511,12 +512,13 @@ class CycadPart(Location):
         return self._base_path / self.part_no
 
     @property
-    def center(self) -> list:
+    def center(self) -> tuple[float, float, float]:
         """Return the center of a part."""
         centered_x = self.position[0] + self.x_max / 2
         centered_y = self.position[1] + self.y_max / 2
         centered_z = self.position[2] + self.z_max / 2
-        return [centered_x, centered_y, centered_z]
+        coordinate = namedtuple("Coordinate", ["x", "y", "z"])
+        return coordinate(x=centered_x, y=centered_y, z=centered_z)
 
     def save(self, path: Path | str | None = None):
         """

--- a/src/cycax/cycad/features.py
+++ b/src/cycax/cycad/features.py
@@ -4,7 +4,7 @@
 
 import typing
 
-from cycax.cycad.location import BACK, BOTTOM, FRONT, LEFT, RIGHT, TOP, Location
+from cycax.cycad.location import BACK, BOTTOM, FRONT, LEFT, RIGHT, Location
 
 
 class Feature(Location):

--- a/tests/test_nut.py
+++ b/tests/test_nut.py
@@ -4,12 +4,10 @@
 
 from pathlib import Path
 
-import pytest
-
 from cycax.cycad import Print3D
 from cycax.cycad.engines.part_build123d import PartEngineBuild123d
 from cycax.cycad.engines.part_freecad import PartEngineFreeCAD
-from tests.shared import hex_code_check, stl_compare, stl_compare_models
+from tests.shared import hex_code_check, stl_compare_models
 
 
 def nutty_cube(tmp_path: Path):


### PR DESCRIPTION
Added an level method on assembly so that the level of assemblies work in the same way as level on Part.

Test example: 
```
if __name__ == "__main__":
    tank = assemble()
    frame = dual_gpu5u_a.assemble()
    tank.add(frame)
    frame.level(top=tank.top, right=tank.right)
    assembly = tank.combine_all_assemblies()
    assembly.save(Path(f"./build/{assembly.name}"))
    assembly.build(AssemblyBuild123d(assembly.name), part_engines=[PartEngineBuild123d()])
```
Ticket https://tsolo.atlassian.net/browse/KUAT-83