### PR TITLE
KUAT-83 Added the move method to assembly.

### DIFF
--- a/src/cycax/cycad/assembly_side.py
+++ b/src/cycax/cycad/assembly_side.py
@@ -68,20 +68,20 @@ class AssemblySide:
         to_here = assembly2_bounding_box[assembly2_side]
 
         if assembly1_side == BOTTOM:
-            assembly1.at(z=to_here)
+            assembly1.at(min_z=to_here)
         elif assembly1_side == TOP:
             z_size = assembly1_bounding_box[TOP] - assembly1_bounding_box[BOTTOM]
-            assembly1.at(z=to_here - z_size)
+            assembly1.at(min_z=to_here - z_size)
         elif assembly1_side == LEFT:
-            assembly1.at(x=to_here)
+            assembly1.at(min_x=to_here)
         elif assembly1_side == RIGHT:
             x_size = assembly1_bounding_box[RIGHT] - assembly1_bounding_box[LEFT]
-            assembly1.at(x=to_here - x_size)
+            assembly1.at(min_x=to_here - x_size)
         elif assembly1_side == FRONT:
-            assembly1.at(y=to_here)
+            assembly1.at(min_y=to_here)
         elif assembly1_side == BACK:
             y_size = assembly1_bounding_box[BACK] - assembly1_bounding_box[FRONT]
-            assembly1.at(y=to_here - y_size)
+            assembly1.at(min_y=to_here - y_size)
         else:
             msg = f"Side: {assembly1_side} is not one of {SIDES}."
             raise ValueError(msg)

--- a/src/cycax/cycad/cycad_part.py
+++ b/src/cycax/cycad/cycad_part.py
@@ -8,6 +8,7 @@ import copy
 import json
 import logging
 import warnings
+from collections import namedtuple
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -511,12 +512,13 @@ class CycadPart(Location):
         return self._base_path / self.part_no
 
     @property
-    def center(self) -> list:
+    def center(self) -> tuple[float, float, float]:
         """Return the center of a part."""
         centered_x = self.position[0] + self.x_max / 2
         centered_y = self.position[1] + self.y_max / 2
         centered_z = self.position[2] + self.z_max / 2
-        return [centered_x, centered_y, centered_z]
+        coordinate = namedtuple("Coordinate", ["x", "y", "z"])
+        return coordinate(x=centered_x, y=centered_y, z=centered_z)
 
     def save(self, path: Path | str | None = None):
         """


### PR DESCRIPTION
Add `move` to assembly and made `at` more versatile. These are essentials to place assemblies with in an assembly.
The `move` and `at` methods on assembly works well.

There is something very slight wrong with centering, it's very close but out by a few mm. When you rotate the part it becomes worst. I have not investigated this properly yet.

Changed center property to return a named tuple. This helps to have cleaner code `pos.x` in place of `pos[0]`, `pos[0]` still works since this is a tuple.