### PR TITLE
Martin/freecad assembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Direct integrations require the
 | Integration | Parts Direct | Assemblies Direct | CyCAx Server Parts | CyCAx Server Assemblies |
 | :------- | :------: | :-------: | :-------: | :-------: |
 | [OpenSCAD](https://github.com/openscad/openscad) | Yes | Yes | No | No |
-| [FreeCAD](https://github.com/FreeCAD/FreeCAD) | Yes | No | [Yes](https://github.com/tsolo-io/cycax-freecad-worker) | No |
+| [FreeCAD](https://github.com/FreeCAD/FreeCAD) | Yes | Yes | [Yes](https://github.com/tsolo-io/cycax-freecad-worker) | No |
 | [Blender](https://blender.org) | No | No | No | [Yes](https://github.com/tsolo-io/cycax-blender-worker) |
 | [build123d](https://github.com/build123d/build123d) | Yes | Yes | No | No |
 

--- a/src/cycax/cli/cmd_build.py
+++ b/src/cycax/cli/cmd_build.py
@@ -31,19 +31,29 @@ def build_freecad(
 
     # Loop through the build order and build the parts.
     from cycax.cycad.engines.part_freecad import bulk_build  # noqa PLC0415 Import here to make CLI faster
+    from cycax.cycad.engines.engine_freecad import EngineFreeCAD
 
     write_back_to_cache = []
-    freecad_list = []
+    freecad_part_list = []
+    freecad_assembly_list = []
     for part in compiler.build_order():
         if not compiler.from_cache(part):
-            write_back_to_cache.append(part)
-            if not part["assembly"]:
-                freecad_list.append(str(part["definition_file"]))
+            if part["assembly"]:
+                freecad_assembly_list.append(str(part["definition_file"]))
+            else:
+                write_back_to_cache.append(part)
+                freecad_part_list.append(str(part["definition_file"]))
 
-    if freecad_list:
+    if freecad_part_list:
         bulk_build(
-            app_bin=compiler.settings["freecad_app"], path=compiler.settings["build_directory"], parts=freecad_list
+            app_bin=compiler.settings["freecad_app"], path=compiler.settings["build_directory"], parts=freecad_part_list
         )
+    if freecad_assembly_list:
+        #     bulk_build(
+        #         app_bin=compiler.settings["freecad_app"], path=compiler.settings["build_directory"], parts=freecad_assembly_list, assembly=True
+        #     )
+        engine = EngineFreeCAD()
+        engine.build_bulk(freecad_assembly_list)
 
     for part in write_back_to_cache:
         compiler.to_cache(part)

--- a/src/cycax/cli/cmd_build.py
+++ b/src/cycax/cli/cmd_build.py
@@ -49,9 +49,6 @@ def build_freecad(
             app_bin=compiler.settings["freecad_app"], path=compiler.settings["build_directory"], parts=freecad_part_list
         )
     if freecad_assembly_list:
-        #     bulk_build(
-        #         app_bin=compiler.settings["freecad_app"], path=compiler.settings["build_directory"], parts=freecad_assembly_list, assembly=True
-        #     )
         engine = EngineFreeCAD()
         engine.build_bulk(freecad_assembly_list)
 

--- a/src/cycax/cli/cmd_cache.py
+++ b/src/cycax/cli/cmd_cache.py
@@ -54,7 +54,7 @@ def cache_list(
     Sort order can be reversed by using the --reverse option.
     """
     cache_path = ctx.obj.config.cache_directory
-    cache_stat_list = get_cache_list(cache_path, reverse, ctime, atime)
+    cache_stat_list = get_cache_list(cache_path, reverse=reverse, ctime=ctime, atime=atime)
     print_table(ctx, cache_stat_list, "Cache Summary")
 
 

--- a/src/cycax/cycad/__init__.py
+++ b/src/cycax/cycad/__init__.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from cycax.cycad.assembly import Assembly  # noqa: F401
+from cycax.cycad.assembly_freecad import AssemblyFreeCAD  # noqa: F401
 from cycax.cycad.assembly_side import (
     AssemblySideBack,
     AssemblySideBottom,
@@ -16,3 +17,4 @@ from cycax.cycad.assembly_side import (
 from cycax.cycad.cuboid import Cuboid, Cylinder, Print3D, SheetMetal  # noqa: F401
 from cycax.cycad.cycad_part import CycadPart  # noqa: F401
 from cycax.cycad.cycad_side import BackSide, BottomSide, FrontSide, LeftSide, RightSide, TopSide  # noqa: F401
+from cycax.cycad.engines import Engine, EngineFreeCAD, EngineOpenSCAD  # noqa: F401

--- a/src/cycax/cycad/assembly.py
+++ b/src/cycax/cycad/assembly.py
@@ -9,6 +9,7 @@ from collections import defaultdict, namedtuple
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 
+from cycax.cycad.assembly_freecad import AssemblyFreeCAD
 from cycax.cycad.assembly_openscad import AssemblyOpenSCAD
 from cycax.cycad.assembly_side import (
     AssemblySide,
@@ -52,9 +53,11 @@ class Assembly:
         logging.info("Calling to the assembler")
         if engine.lower() == "openscad":
             assembler = AssemblyOpenSCAD(self.name, config=engine_config)
+        elif engine.lower() == "freecad":
+            assembler = AssemblyFreeCAD(self.name, config=engine_config)
         else:
-            msg = f"""Engine {engine} is not one of the recognized engines for assebling parts.
-                Choose one of OpenSCAD (default) or Blender."""
+            msg = f"""Engine {engine} is not one of the recognized engines for assembling parts.
+                Choose one of OpenSCAD (default), FreeCAD, or Blender."""
             raise ValueError(msg)
         return assembler
 
@@ -186,7 +189,7 @@ class Assembly:
                 engine.add(action)
             engine.build()
 
-    def save(self, path: Path | str | None = None) -> list[Path]:
+    def save(self, path: Path | str | None = None) -> Path:
         """Save the assembly and parts to JSON files.
 
         Args:

--- a/src/cycax/cycad/assembly_freecad.py
+++ b/src/cycax/cycad/assembly_freecad.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: 2025 Tsolo.io
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+import orjson
+
+from cycax.cycad.engines.base_assembly_engine import AssemblyEngine
+
+
+class AssemblyFreeCAD(AssemblyEngine):
+    """Assemble the parts into a FreeCAD model.
+
+    Attributes:
+        name: The part number of the complex part that is being assembled.
+        config: Configuration for the FreeCAD assembly engine.
+    """
+
+    def __init__(self, name: str, config: dict | None = None) -> None:
+        self.name = name
+        self._base_path = Path(".")
+        self._config = {} if config is None else config
+        self._parts = []
+
+    def add(self, part_operation: dict):
+        """Add a part to the assembly.
+
+        Args:
+            part_operation: Dictionary containing part information:
+                - part_no: Part identifier
+                - position: [x, y, z] position
+                - rotate: List of rotation operations
+                - rotmax: [x_size, y_size, z_size] dimensions
+                - colour: Part color
+                - hash: Part hash
+        """
+        self._parts.append(part_operation)
+
+    def get_freecad_app(self) -> Path:
+        """Get the FreeCAD application binary path.
+
+        Returns:
+            Path to FreeCAD binary.
+
+        Raises:
+            FileNotFoundError: If FreeCAD binary cannot be found.
+        """
+        # Check if specified in config
+        if self._config.get("freecad_app"):
+            app_path = Path(self._config["freecad_app"])
+            if app_path.exists():
+                return app_path
+
+        # Search common locations for AppImage
+        search_paths = [
+            Path("~/Applications").expanduser(),
+            Path.home() / "Applications",
+            self._base_path,
+        ]
+
+        for search_path in search_paths:
+            if search_path.exists():
+                for appimg in search_path.glob("FreeCAD*.AppImage"):
+                    logging.info(f"Found FreeCAD AppImage: {appimg}")
+                    return appimg
+
+        msg = "FreeCAD binary not found. Please specify 'freecad_app' in config or install FreeCAD AppImage."
+        raise FileNotFoundError(msg)
+
+    def build(self, path: Path | None = None):
+        """Create the assembly from the added parts.
+
+        Args:
+            path: The path where the assembly will be stored.
+
+        Raises:
+            ValueError: If no parts have been added.
+            FileNotFoundError: If FreeCAD binary cannot be found.
+        """
+        if path is not None:
+            self._base_path = path
+
+        if not self._parts:
+            msg = "No parts added to the assembly. Please call add() to add parts."
+            raise ValueError(msg)
+
+        # Create assembly JSON data
+        assembly_data = {"name": self.name, "parts": self._parts}
+
+        # Write assembly JSON to file
+        assembly_json_file = self._base_path / f"{self.name}.json"
+        assembly_json_file.write_text(orjson.dumps(assembly_data).decode("utf-8"))
+        logging.info(f"Created assembly JSON: {assembly_json_file}")
+
+        # Get FreeCAD binary
+        try:
+            freecad_app = self.get_freecad_app()
+        except FileNotFoundError as e:
+            logging.error(str(e))
+            return
+
+        # Get the FreeCAD assembly script
+        freecad_script = Path(__file__).resolve().parent / "engines" / "cycax_assembly_freecad.py"
+
+        if not freecad_script.exists():
+            logging.error(f"FreeCAD assembly script not found: {freecad_script}")
+            return
+
+        # Prepare environment variables
+        environment = dict(os.environ)
+        environment.update(
+            {
+                "CYCAX_JSON": str(assembly_json_file),
+                "CYCAX_CWD": str(self._base_path),
+                "CYCAX_OUT_FORMATS": self._config.get("out_formats", "STL,PNG"),
+            }
+        )
+
+        # Execute FreeCAD
+        logging.info(f"Running FreeCAD assembly with: {freecad_app}")
+        result = subprocess.run(
+            [str(freecad_app), str(freecad_script)],
+            capture_output=True,
+            text=True,
+            env=environment,
+            shell=False,
+            check=False,
+        )
+
+        if result.stdout:
+            logging.info(f"FreeCAD: {result.stdout}")
+        if result.stderr:
+            logging.error(f"FreeCAD: {result.stderr}")
+
+        if result.returncode == 0:
+            logging.info(f"Successfully created FreeCAD assembly: {self.name}")
+        else:
+            logging.error(f"FreeCAD assembly failed with return code: {result.returncode}")

--- a/src/cycax/cycad/engines/__init__.py
+++ b/src/cycax/cycad/engines/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Tsolo.io
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from cycax.cycad.engines.base_engine import Engine  # noqa: F401
+from cycax.cycad.engines.engine_freecad import EngineFreeCAD  # noqa: F401
+from cycax.cycad.engines.engine_openscad import EngineOpenSCAD  # noqa: F401

--- a/src/cycax/cycad/engines/base_engine.py
+++ b/src/cycax/cycad/engines/base_engine.py
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: 2025 Tsolo.io
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import logging
+from pathlib import Path
+
+
+class Engine:
+    """Base class for unified engines that can build both parts and assemblies.
+
+    Unlike separate PartEngine and AssemblyEngine classes, this unified Engine
+    can process JSON files containing either part definitions (with "features")
+    or assembly definitions (with "parts") and build them accordingly.
+
+    Attributes:
+        config: Engine-specific configuration dictionary.
+    """
+
+    def __init__(self, config: dict | None = None):
+        """Initialize the engine.
+
+        Args:
+            config: Optional configuration dictionary for the engine.
+        """
+        self.config = dict(config or {})
+        self.name = ""
+        self._base_path = Path(".")
+
+    def set_name(self, name: str):
+        """Set the name of the engine.
+
+        Args:
+            name: Name to set for the engine.
+        """
+        self.name = name
+
+    def set_path(self, path: Path | str):
+        """Set the base path for the engine.
+
+        Args:
+            path: Base path to set for the engine.
+        """
+        self._base_path = Path(path)
+
+    def new(self, name: str, path: Path):
+        self.name = name
+        self.set_path(path)
+
+    def create(self, *args, **kwargs):
+        pass
+
+    def is_part(self, data: dict) -> bool:
+        """Determine if JSON data represents a part.
+
+        Args:
+            data: Parsed JSON data.
+
+        Returns:
+            True if data represents a part (has "features"), False otherwise.
+        """
+        return "features" in data
+
+    def is_assembly(self, data: dict) -> bool:
+        """Determine if JSON data represents an assembly.
+
+        Args:
+            data: Parsed JSON data.
+
+        Returns:
+            True if data represents an assembly (has "parts"), False otherwise.
+        """
+        return "parts" in data
+
+    def load_json(self, json_file: Path) -> dict:
+        """Load and parse a JSON file.
+
+        Args:
+            json_file: Path to the JSON file.
+
+        Returns:
+            Parsed JSON data as a dictionary.
+
+        Raises:
+            FileNotFoundError: If the JSON file doesn't exist.
+        """
+        json_path = Path(json_file).expanduser().resolve().absolute()
+        if not json_path.exists():
+            msg = f"JSON file not found: {json_path}"
+            raise FileNotFoundError(msg)
+
+        data = json.loads(json_path.read_text())
+        return data
+
+    def build_part(self, json_file: Path) -> list[dict]:
+        """Build a part from its JSON definition.
+
+        This method should be implemented by subclasses to handle
+        part-specific building logic.
+
+        Args:
+            json_file: Path to the part JSON file.
+
+        Returns:
+            List of generated file information dictionaries.
+
+        Raises:
+            NotImplementedError: If not implemented by subclass.
+        """
+        msg = "build_part must be implemented by subclass"
+        raise NotImplementedError(msg)
+
+    def build_assembly(self, json_file: Path) -> list[dict]:
+        """Build an assembly from its JSON definition.
+
+        This method should be implemented by subclasses to handle
+        assembly-specific building logic.
+
+        Args:
+            json_file: Path to the assembly JSON file.
+
+        Returns:
+            List of generated file information dictionaries.
+
+        Raises:
+            NotImplementedError: If not implemented by subclass.
+        """
+        msg = "build_assembly must be implemented by subclass"
+        raise NotImplementedError(msg)
+
+    def build_bulk(self, json_files: list[Path] | Path) -> list[dict]:
+        """Build parts and assemblies from a list of JSON files.
+
+        This method processes JSON files in order, automatically detecting
+        whether each file represents a part or an assembly and building
+        accordingly. Artifacts are placed in the same directory as the
+        JSON file.
+
+        Args:
+            json_files: Single Path or list of Paths to JSON files to build.
+
+        Returns:
+            List of all generated file information dictionaries.
+        """
+        if isinstance(json_files, Path):
+            json_files = [json_files]
+
+        all_artifacts = []
+
+        for json_file in json_files:
+            json_path = Path(json_file).expanduser().resolve().absolute()
+            logging.info(f"Processing: {json_path}")
+
+            try:
+                data = self.load_json(json_path)
+
+                if self.is_part(data):
+                    logging.info(f"Building part: {data.get('name', 'unknown')}")
+                    artifacts = self.build_part(json_path)
+                elif self.is_assembly(data):
+                    logging.info(f"Building assembly: {data.get('name', 'unknown')}")
+                    artifacts = self.build_assembly(json_path)
+                else:
+                    logging.warning(f"Unknown JSON type (no 'features' or 'parts'): {json_path}")
+                    continue
+
+                all_artifacts.extend(artifacts)
+
+            except Exception as error:
+                logging.error(f"Error processing {json_path}: {error}")
+                continue
+
+        return all_artifacts
+
+    def file_list(self, files: list[dict], engine_name: str, score: int = 5) -> list[dict]:
+        """Generate a standardized list of artifact files.
+
+        Args:
+            files: List of file dictionaries with 'file' key (Path).
+            engine_name: Name of the engine that generated the files.
+            score: Priority score for the files (higher is better).
+
+        Returns:
+            List of file information dictionaries with metadata.
+        """
+        artifact_files = []
+        for file_info in files:
+            filepath = file_info["file"]
+            if filepath.exists():
+                file_info["type"] = filepath.suffix.strip(".").upper()
+                file_info["engine"] = engine_name
+                file_info["score"] = score
+                artifact_files.append(file_info)
+            else:
+                logging.warning(f"File does not exist: {filepath}")
+
+        return artifact_files

--- a/src/cycax/cycad/engines/base_engine.py
+++ b/src/cycax/cycad/engines/base_engine.py
@@ -25,31 +25,6 @@ class Engine:
             config: Optional configuration dictionary for the engine.
         """
         self.config = dict(config or {})
-        self.name = ""
-        self._base_path = Path(".")
-
-    def set_name(self, name: str):
-        """Set the name of the engine.
-
-        Args:
-            name: Name to set for the engine.
-        """
-        self.name = name
-
-    def set_path(self, path: Path | str):
-        """Set the base path for the engine.
-
-        Args:
-            path: Base path to set for the engine.
-        """
-        self._base_path = Path(path)
-
-    def new(self, name: str, path: Path):
-        self.name = name
-        self.set_path(path)
-
-    def create(self, *args, **kwargs):
-        pass
 
     def is_part(self, data: dict) -> bool:
         """Determine if JSON data represents a part.

--- a/src/cycax/cycad/engines/cycax_assembly_freecad.py
+++ b/src/cycax/cycad/engines/cycax_assembly_freecad.py
@@ -1,0 +1,335 @@
+# SPDX-FileCopyrightText: 2025 Tsolo.io
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This file is called directly from FreeCAD.
+# CyCAx launches the FreeCAD binary and passes in:
+# 1. The fullpath to this file.
+# 2. The path to the assembly JSON file; as environmental variable ("CYCAX_JSON")
+# 3. The path to where the output files should be stored; as environmental variable ("CYCAX_CWD")
+# 4. The file types that need to be generated; as environmental variable ("CYCAX_OUT_FORMATS")
+
+# How to use this file:
+# 1. Open the file up in FreeCAD and run as a Macro.
+# 2. Run from command line. ./FreeCAD.AppImage cycax_assembly_freecad.py
+
+import json
+import logging
+import os
+from pathlib import Path
+
+import FreeCAD
+import FreeCAD as App
+import FreeCADGui
+import Import
+import importDXF
+import importSVG
+import Part
+from FreeCAD import Rotation, Vector
+from PySide import QtGui
+
+logging.info("Open FreeCAD for Assembly")
+
+LEFT = "LEFT"
+RIGHT = "RIGHT"
+TOP = "TOP"
+BOTTOM = "BOTTOM"
+FRONT = "FRONT"
+BACK = "BACK"
+
+
+def axis_vector(axis: str) -> Vector:
+    _axis = axis.lower()[0]
+    if _axis == "x":
+        return Vector(1, 0, 0)
+    elif _axis == "y":
+        return Vector(0, 1, 0)
+    elif _axis == "z":
+        return Vector(0, 0, 1)
+    else:
+        raise ValueError(f"Invalid axis: {_axis}")
+
+
+class EngineFreecadAssembly:
+    """This class will be used in FreeCAD to assemble parts from a JSON definition.
+
+    Args:
+        base_path: the path where the outputs need to be stored.
+    """
+
+    def __init__(self, base_path: Path):
+        self._base_path = base_path
+        self.filepath = ""
+        self.name = ""
+
+    def _import_part(self, part_no: str, base_path: Path):
+        """Import a part STL or STEP file.
+
+        Args:
+            part_no: The part number/name to import.
+            base_path: The base directory where parts are stored.
+
+        Returns:
+            The imported object in FreeCAD.
+        """
+        # Try to find STEP file first (preferred), then STL
+        step_file = base_path / part_no / f"{part_no}-freecad.step"
+        stl_file = base_path / part_no / f"{part_no}-freecad.stl"
+
+        obj = FreeCAD.ActiveDocument.addObject("Part::Feature", part_no)
+
+        if step_file.exists():
+            obj.Shape = Part.read(str(step_file))
+            logging.info(f"Imported STEP file: {step_file}")
+        elif stl_file.exists():
+            obj.Shape = Part.read(str(stl_file))
+            logging.info(f"Imported STL file: {stl_file}")
+        else:
+            logging.warning(f"No STEP or STL file found for part: {part_no}")
+            return None
+        return obj
+
+    def _apply_rotation(self, rotate_list: list) -> Rotation:
+        """Apply rotation transformations based on the rotate list.
+
+        Args:
+            rotate_list: List of rotation operations.
+
+        Returns:
+            FreeCAD Rotation object.
+        """
+        rotation = Rotation(Vector(1, 0, 0), 0)
+
+        for item in rotate_list:
+            # TODO: Use angle from file.
+            axis = item["axis"].lower()
+            if axis == "x":
+                rotation = rotation * Rotation(Vector(1, 0, 0), 90)
+            elif axis == "y":
+                rotation = rotation * Rotation(Vector(0, 1, 0), 90)
+            elif axis == "z":
+                rotation = rotation * Rotation(Vector(0, 0, 1), 90)
+            else:
+                logging.error(f"Invalid rotation axis: {axis}")
+
+        return rotation
+
+    def _set_color(self, obj, colour: str):
+        """Set the color of an object.
+
+        Args:
+            obj: FreeCAD object.
+            colour: Color name (e.g., "orange", "blue").
+        """
+        color_map = {
+            "orange": (1.0, 0.5, 0.0),
+            "blue": (0.0, 0.0, 1.0),
+            "red": (1.0, 0.0, 0.0),
+            "green": (0.0, 1.0, 0.0),
+            "yellow": (1.0, 1.0, 0.0),
+            "purple": (0.5, 0.0, 0.5),
+            "white": (1.0, 1.0, 1.0),
+            "black": (0.0, 0.0, 0.0),
+            "gray": (0.5, 0.5, 0.5),
+            "grey": (0.5, 0.5, 0.5),
+        }
+
+        rgb = color_map.get(colour.lower(), (1.0, 0.5, 0.0))  # Default to orange
+        if hasattr(obj, "ViewObject") and obj.ViewObject:
+            obj.ViewObject.ShapeColor = rgb
+
+    def render_to_png(self, view: str | None = None):
+        """Used to create a png of the desired view.
+
+        Args:
+            view: The side of the object the png will be produced from.
+        """
+        active_doc = FreeCADGui.activeDocument()
+        view = self.change_view(active_doc=active_doc, side=view, default="ALL")
+        FreeCADGui.SendMsgToActiveView("ViewFit")
+
+        target_image_file = f"{self.filepath}-{view}.png"
+        active_doc.activeView().fitAll()
+        active_doc.activeView().saveImage(str(target_image_file), 2000, 1800, "White")
+
+    def change_view(self, active_doc: FreeCADGui.activeDocument, side: str, default: str | None = None):
+        """This will change the gui view to show the specified side.
+
+        Args:
+            active_doc: FreeCAD active doc.
+            side: The side the view is from.
+            default: The default side for that view.
+        """
+        if side is None:
+            side = default
+
+        match side.upper().strip():
+            case "TOP":
+                active_doc.activeView().viewTop()
+            case "BACK":
+                active_doc.activeView().viewRear()
+            case "REAR":
+                active_doc.activeView().viewRear()
+            case "BOTTOM":
+                active_doc.activeView().viewBottom()
+            case "FRONT":
+                active_doc.activeView().viewFront()
+            case "LEFT":
+                active_doc.activeView().viewLeft()
+            case "RIGHT":
+                active_doc.activeView().viewRight()
+            case "ALL":
+                active_doc.activeView().viewAxometric()
+            case _:
+                msg = f"side: {side} is not one of TOP, BOTTOM, LEFT, RIGHT, FRONT, BACK OR ALL."
+                raise ValueError(msg)
+        return side
+
+    def render_to_dxf(self, active_doc: App.Document, view: str | None = None):
+        """This method will be used for creating a dxf of the object currently in view.
+
+        Args:
+            active_doc: The FreeCAD document.
+            view: The side from which to produce the output file.
+        """
+        view_doc = FreeCADGui.activeDocument()
+        view = self.change_view(active_doc=view_doc, side=view, default="TOP")
+        FreeCADGui.SendMsgToActiveView("ViewFit")
+        __objs__ = [obj for obj in active_doc.Objects if obj.ViewObject.Visibility]
+
+        importDXF.export(__objs__, str(f"{self.filepath}-{view}.dxf"))
+
+    def render_to_svg(self, active_doc: App.Document, view: str | None = None):
+        """This method will be used for creating a svg of the object currently in view.
+
+        Args:
+            active_doc: The FreeCAD document.
+            view: The side from which to produce the output file.
+        """
+        view_doc = FreeCADGui.activeDocument()
+        view = self.change_view(active_doc=view_doc, side=view, default="TOP")
+        FreeCADGui.SendMsgToActiveView("ViewFit")
+        __objs__ = [obj for obj in active_doc.Objects if obj.ViewObject.Visibility]
+
+        importSVG.export(__objs__, str(f"{self.filepath}-{view}.svg"))
+
+    def render_to_stl(self, active_doc: App.Document):
+        """This method will be used for creating a STL of the assembly.
+
+        Args:
+            active_doc: The FreeCAD document.
+        """
+        # Export all visible objects
+        visible_objects = [obj for obj in active_doc.Objects if obj.ViewObject.Visibility]
+
+        if visible_objects:
+            # Fuse all parts into a single compound
+            shapes = [obj.Shape for obj in visible_objects if hasattr(obj, "Shape")]
+            if shapes:
+                compound = Part.makeCompound(shapes)
+                filename = f"{self.filepath}.stl"
+                compound.exportStl(filename)
+                logging.info(f"Exported assembly STL: {filename}")
+
+                # Also export STEP
+                filename_step = f"{self.filepath}.step"
+                compound.exportStep(filename_step)
+                logging.info(f"Exported assembly STEP: {filename_step}")
+
+    def build(self, definition: dict, outformats: str):
+        """Assemble parts based on the JSON definition.
+
+        Args:
+            definition: Assembly definition from JSON.
+            outformats: CSV containing output formats.
+        """
+        self.name = definition["name"]
+
+        # Close existing document if it exists
+        if FreeCAD.ActiveDocument:
+            FreeCAD.closeDocument(self.name)
+
+        # Create new document
+        doc = FreeCAD.newDocument(self.name)
+
+        # Import and position each part
+        for part_data in definition["parts"]:
+            part_no = part_data["part_no"]
+            position = part_data["position"]
+            rotate_list = part_data["rotate"]
+            part_data["rotmax"]
+            colour = part_data.get("colour", "orange")
+            # Import the part
+            obj = self._import_part(part_no, self._base_path)
+            print(part_data, obj)
+
+            if obj:
+                # Find the imported object(s) - FreeCAD may create multiple objects
+                # imported_objs = [obj for obj in doc.Objects if part_no.lower() in obj.Label.lower()]
+                # print("Import OBJS", imported_objs)
+
+                # Apply rotation
+                # rotation = self._apply_rotation(rotate_list)
+                # final_position = Vector(*position)
+
+                for rotation_spec in rotate_list:
+                    axis = rotation_spec["axis"]
+                    angle = rotation_spec["angle"]
+                    rotation = Rotation(axis_vector(axis), angle)
+                    obj.Placement.Rotation = rotation * obj.Placement.Rotation
+                    print(rotation_spec)
+                # obj.Placement = App.Placement(final_position, rotation)
+
+                bounding_box = obj.Shape.BoundBox
+                mx = position[0] - bounding_box.XMin
+                my = position[1] - bounding_box.YMin
+                mz = position[2] - bounding_box.ZMin
+                obj.Placement.Base += FreeCAD.Vector(mx, my, mz)
+
+                # Set color
+                self._set_color(obj, colour)
+
+        # Recompute the document
+        doc.recompute()
+        FreeCADGui.activeDocument().activeView().viewAxometric()
+        FreeCADGui.SendMsgToActiveView("ViewFit")
+
+        # Save the assembly
+        self.filepath = self._base_path / f"{self.name}-assembly"
+        doc.saveCopy(f"{self.filepath}.FCStd")
+
+        # Generate output formats
+        for out_choice in outformats.lower().split(","):
+            ftype, fview = out_choice.split(":") if ":" in out_choice else (out_choice, None)
+            out_format = ftype.upper().strip()
+            match out_format:
+                case "PNG":
+                    self.render_to_png(view=fview)
+                case "DXF":
+                    self.render_to_dxf(view=fview, active_doc=doc)
+                case "SVG":
+                    self.render_to_svg(view=fview, active_doc=doc)
+                case "STL":
+                    self.render_to_stl(active_doc=doc)
+                case _:
+                    msg = f"file_type: {out_format} is not one of PNG, DXF, SVG or STL."
+                    raise ValueError(msg)
+
+        App.closeDocument(self.name)
+
+
+try:
+    json_file = os.getenv("CYCAX_JSON")
+    out_dir = os.getenv("CYCAX_CWD")
+    files_to_produce = os.getenv("CYCAX_OUT_FORMATS", "STL,PNG")
+
+    engine = EngineFreecadAssembly(Path(out_dir))
+
+    definition = json.loads(Path(json_file).read_text())
+    logging.info(f"Assembly JSON file: {json_file}, output dir: {out_dir}")
+    engine.build(definition, files_to_produce.replace(" ", ""))
+except Exception as error:
+    logging.exception(error)
+    raise error
+finally:
+    QtGui.QApplication.quit()

--- a/src/cycax/cycad/engines/cycax_assembly_freecad.py
+++ b/src/cycax/cycad/engines/cycax_assembly_freecad.py
@@ -72,47 +72,21 @@ class EngineFreecadAssembly:
         Returns:
             The imported object in FreeCAD.
         """
-        # Try to find STEP file first (preferred), then STL
-        step_file = base_path / part_no / f"{part_no}-freecad.step"
-        stl_file = base_path / part_no / f"{part_no}-freecad.stl"
 
-        obj = FreeCAD.ActiveDocument.addObject("Part::Feature", part_no)
+        for made_by in ("freecad", "build123d", "openscad", None):
+            for ext in ("step", "stl"):
+                if made_by is None:
+                    _file = base_path / part_no / f"{part_no}.{ext}"
+                else:
+                    _file = base_path / part_no / f"{part_no}-{made_by}.{ext}"
+                if _file.exists():
+                    obj = FreeCAD.ActiveDocument.addObject("Part::Feature", part_no)
+                    obj.Shape = Part.read(str(_file))
+                    logging.info(f"Imported {ext.upper()} made by {made_by} file: {_file}")
+                    return obj
 
-        if step_file.exists():
-            obj.Shape = Part.read(str(step_file))
-            logging.info(f"Imported STEP file: {step_file}")
-        elif stl_file.exists():
-            obj.Shape = Part.read(str(stl_file))
-            logging.info(f"Imported STL file: {stl_file}")
-        else:
-            logging.warning(f"No STEP or STL file found for part: {part_no}")
-            return None
-        return obj
-
-    def _apply_rotation(self, rotate_list: list) -> Rotation:
-        """Apply rotation transformations based on the rotate list.
-
-        Args:
-            rotate_list: List of rotation operations.
-
-        Returns:
-            FreeCAD Rotation object.
-        """
-        rotation = Rotation(Vector(1, 0, 0), 0)
-
-        for item in rotate_list:
-            # TODO: Use angle from file.
-            axis = item["axis"].lower()
-            if axis == "x":
-                rotation = rotation * Rotation(Vector(1, 0, 0), 90)
-            elif axis == "y":
-                rotation = rotation * Rotation(Vector(0, 1, 0), 90)
-            elif axis == "z":
-                rotation = rotation * Rotation(Vector(0, 0, 1), 90)
-            else:
-                logging.error(f"Invalid rotation axis: {axis}")
-
-        return rotation
+        logging.error(f"No STEP or STL file found for part: {part_no}")
+        return None
 
     def _set_color(self, obj, colour: str):
         """Set the color of an object.
@@ -166,9 +140,7 @@ class EngineFreecadAssembly:
         match side.upper().strip():
             case "TOP":
                 active_doc.activeView().viewTop()
-            case "BACK":
-                active_doc.activeView().viewRear()
-            case "REAR":
+            case "BACK" | "REAR":
                 active_doc.activeView().viewRear()
             case "BOTTOM":
                 active_doc.activeView().viewBottom()
@@ -264,21 +236,9 @@ class EngineFreecadAssembly:
             print(part_data, obj)
 
             if obj:
-                # Find the imported object(s) - FreeCAD may create multiple objects
-                # imported_objs = [obj for obj in doc.Objects if part_no.lower() in obj.Label.lower()]
-                # print("Import OBJS", imported_objs)
-
-                # Apply rotation
-                # rotation = self._apply_rotation(rotate_list)
-                # final_position = Vector(*position)
-
                 for rotation_spec in rotate_list:
-                    axis = rotation_spec["axis"]
-                    angle = rotation_spec["angle"]
-                    rotation = Rotation(axis_vector(axis), angle)
+                    rotation = Rotation(axis_vector(rotation_spec["axis"]), rotation_spec["angle"])
                     obj.Placement.Rotation = rotation * obj.Placement.Rotation
-                    print(rotation_spec)
-                # obj.Placement = App.Placement(final_position, rotation)
 
                 bounding_box = obj.Shape.BoundBox
                 mx = position[0] - bounding_box.XMin
@@ -295,7 +255,7 @@ class EngineFreecadAssembly:
         FreeCADGui.SendMsgToActiveView("ViewFit")
 
         # Save the assembly
-        self.filepath = self._base_path / f"{self.name}-assembly"
+        self.filepath = self._base_path / f"{self.name}-freecad"
         doc.saveCopy(f"{self.filepath}.FCStd")
 
         # Generate output formats

--- a/src/cycax/cycad/engines/engine_freecad.py
+++ b/src/cycax/cycad/engines/engine_freecad.py
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: 2025 Tsolo.io
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+import orjson
+
+from cycax.cycad.engines.base_engine import Engine
+from cycax.cycad.location import TOP
+
+
+class EngineFreeCAD(Engine):
+    """Unified FreeCAD engine for building both parts and assemblies.
+
+    This engine can process JSON files containing either part definitions
+    (with "features") or assembly definitions (with "parts") and build
+    them using FreeCAD.
+
+    Attributes:
+        config: Configuration dictionary supporting:
+            - freecad_app: Path to FreeCAD binary (optional)
+            - out_formats: Output formats (default: "STL,PNG")
+    """
+
+    def __init__(self, config: dict | None = None):
+        """Initialize the FreeCAD engine.
+
+        Args:
+            config: Optional configuration dictionary.
+        """
+        super().__init__(config)
+        self.engine_name = "FreeCAD"
+
+    def get_freecad_app(self, base_path: Path | None = None) -> Path:
+        """Get the FreeCAD application binary path.
+
+        Args:
+            base_path: Optional base path to search for FreeCAD.
+
+        Returns:
+            Path to FreeCAD binary.
+
+        Raises:
+            FileNotFoundError: If FreeCAD binary cannot be found.
+        """
+        # Check if specified in config
+        if self.config.get("freecad_app"):
+            app_path = Path(self.config["freecad_app"])
+            if app_path.exists():
+                return app_path
+
+        # Search common locations for AppImage
+        search_paths = [
+            Path("~/Applications").expanduser(),
+            Path.home() / "Applications",
+        ]
+
+        if base_path:
+            search_paths.append(base_path)
+
+        for search_path in search_paths:
+            if search_path.exists():
+                for appimg in search_path.glob("FreeCAD*.AppImage"):
+                    logging.info(f"Found FreeCAD AppImage: {appimg}")
+                    return appimg
+
+        msg = "FreeCAD binary not found. Please specify 'freecad_app' in config or install FreeCAD AppImage."
+        raise FileNotFoundError(msg)
+
+    def build_part(self, json_file: Path) -> list[dict]:
+        """Build a part using FreeCAD.
+
+        Args:
+            json_file: Path to the part JSON file.
+
+        Returns:
+            List of generated file information dictionaries.
+        """
+        json_path = Path(json_file).expanduser().resolve().absolute()
+        data = self.load_json(json_path)
+        name = data.get("name", json_path.stem)
+        base_path = json_path.parent.parent  # Go up to parent directory
+
+        # Check if features exist
+        if not data.get("features"):
+            logging.warning(f"No features found in part JSON: {json_path}")
+            return []
+
+        # Get FreeCAD binary
+        try:
+            freecad_app = self.get_freecad_app(base_path)
+        except FileNotFoundError as e:
+            logging.error(str(e))
+            return []
+
+        # Get the FreeCAD part script
+        freecad_script = Path(__file__).resolve().parent / "cycax_part_freecad.py"
+
+        if not freecad_script.exists():
+            logging.error(f"FreeCAD part script not found: {freecad_script}")
+            return []
+
+        # Prepare environment variables
+        environment = dict(os.environ)
+        out_formats = self.config.get("out_formats", "STL,PNG")
+        environment.update(
+            {
+                "CYCAX_JSON": str(json_path),
+                "CYCAX_CWD": str(base_path),
+                "CYCAX_OUT_FORMATS": out_formats,
+                "CYCAX_MODE": "SINGLE",
+            }
+        )
+
+        # Execute FreeCAD
+        logging.info(f"Building FreeCAD part: {name}")
+        result = subprocess.run(
+            [str(freecad_app), str(freecad_script)],
+            capture_output=True,
+            text=True,
+            env=environment,
+            shell=False,
+            check=False,
+        )
+
+        if result.stdout:
+            logging.info(f"FreeCAD: {result.stdout}")
+        if result.stderr:
+            logging.error(f"FreeCAD: {result.stderr}")
+
+        if result.returncode != 0:
+            logging.error(f"FreeCAD build failed with return code: {result.returncode}")
+
+        # Collect generated files
+        part_dir = json_path.parent
+        files = [
+            {"file": part_dir / f"{name}-freecad.stl"},
+            {"file": part_dir / f"{name}-perspectiveAll.png"},
+            {"file": part_dir / f"{name}-perspective.dxf", "side": TOP},
+            {"file": part_dir / f"{name}-perspectiveTop.png", "side": TOP},
+            {"file": part_dir / f"{name}-freecad.FCStd", "description": "FreeCAD primary source file."},
+            {"file": part_dir / f"{name}-freecad.step"},
+        ]
+
+        return self.file_list(files, self.engine_name, score=5)
+
+    def build_assembly(self, json_file: Path) -> list[dict]:
+        """Build an assembly using FreeCAD.
+
+        Args:
+            json_file: Path to the assembly JSON file.
+
+        Returns:
+            List of generated file information dictionaries.
+        """
+        json_path = Path(json_file).expanduser().resolve().absolute()
+        data = self.load_json(json_path)
+        name = data.get("name", json_path.stem)
+        base_path = json_path.parent
+
+        # Check if parts exist
+        if not data.get("parts"):
+            logging.warning(f"No parts found in assembly JSON: {json_path}")
+            return []
+
+        # Get FreeCAD binary
+        try:
+            freecad_app = self.get_freecad_app(base_path)
+        except FileNotFoundError as e:
+            logging.error(str(e))
+            return []
+
+        # Get the FreeCAD assembly script
+        freecad_script = Path(__file__).resolve().parent / "cycax_assembly_freecad.py"
+
+        if not freecad_script.exists():
+            logging.error(f"FreeCAD assembly script not found: {freecad_script}")
+            return []
+
+        # Prepare environment variables
+        environment = dict(os.environ)
+        out_formats = self.config.get("out_formats", "STL,PNG")
+        environment.update(
+            {
+                "CYCAX_JSON": str(json_path),
+                "CYCAX_CWD": str(base_path),
+                "CYCAX_OUT_FORMATS": out_formats,
+            }
+        )
+
+        # Execute FreeCAD
+        logging.info(f"Building FreeCAD assembly: {name}")
+        result = subprocess.run(
+            [str(freecad_app), str(freecad_script)],
+            capture_output=True,
+            text=True,
+            env=environment,
+            shell=False,
+            check=False,
+        )
+
+        if result.stdout:
+            logging.info(f"FreeCAD: {result.stdout}")
+        if result.stderr:
+            logging.error(f"FreeCAD: {result.stderr}")
+
+        if result.returncode != 0:
+            logging.error(f"FreeCAD assembly build failed with return code: {result.returncode}")
+
+        # Collect generated files
+        assembly_dir = json_path.parent
+        files = [
+            {"file": assembly_dir / f"{name}-assembly.stl"},
+            {"file": assembly_dir / f"{name}-assembly-ALL.png"},
+            {"file": assembly_dir / f"{name}-assembly.FCStd", "description": "FreeCAD assembly source file."},
+            {"file": assembly_dir / f"{name}-assembly.step"},
+        ]
+
+        return self.file_list(files, self.engine_name, score=5)

--- a/src/cycax/cycad/engines/engine_openscad.py
+++ b/src/cycax/cycad/engines/engine_openscad.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: 2025 Tsolo.io
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from pathlib import Path
+
+from cycax.cycad.engines.base_engine import Engine
+from cycax.cycad.engines.part_openscad import PartEngineOpenSCAD
+from cycax.cycad.location import TOP
+
+
+class EngineOpenSCAD(Engine):
+    """Unified OpenSCAD engine for building both parts and assemblies.
+
+    This engine can process JSON files containing either part definitions
+    (with "features") or assembly definitions (with "parts") and build
+    them using OpenSCAD.
+
+    Attributes:
+        config: Configuration dictionary for the engine.
+    """
+
+    def __init__(self, config: dict | None = None):
+        """Initialize the OpenSCAD engine.
+
+        Args:
+            config: Optional configuration dictionary.
+        """
+        super().__init__(config)
+        self.engine_name = "OpenSCAD"
+
+    def build_part(self, json_file: Path) -> list[dict]:
+        """Build a part using OpenSCAD.
+
+        Args:
+            json_file: Path to the part JSON file.
+
+        Returns:
+            List of generated file information dictionaries.
+        """
+        json_path = Path(json_file).expanduser().resolve().absolute()
+        data = self.load_json(json_path)
+        name = data.get("name", json_path.stem)
+        base_path = json_path.parent.parent
+
+        # Check if features exist
+        if not data.get("features"):
+            logging.warning(f"No features found in part JSON: {json_path}")
+            return []
+
+        # Use existing PartEngineOpenSCAD
+        engine = PartEngineOpenSCAD(name=name, path=base_path)
+        engine._json_file = json_path
+
+        try:
+            files = engine.build(None)
+            for file_info in files:
+                logging.info(f"Created {file_info['type']} file: {file_info['file']}")
+            return files
+        except Exception as error:
+            logging.error(f"Error building OpenSCAD part {name}: {error}")
+            return []
+
+    def build_assembly(self, json_file: Path) -> list[dict]:
+        """Build an assembly using OpenSCAD.
+
+        Args:
+            json_file: Path to the assembly JSON file.
+
+        Returns:
+            List of generated file information dictionaries.
+        """
+        json_path = Path(json_file).expanduser().resolve().absolute()
+        data = self.load_json(json_path)
+        name = data.get("name", json_path.stem)
+        base_path = json_path.parent
+
+        # Check if parts exist
+        if not data.get("parts"):
+            logging.warning(f"No parts found in assembly JSON: {json_path}")
+            return []
+
+        # Import here to avoid circular dependencies
+        from cycax.cycad.assembly_openscad import AssemblyOpenSCAD
+
+        # Build each part first
+        for part_data in data["parts"]:
+            part_no = part_data["part_no"]
+            part_json = base_path / part_no / f"{part_no}.json"
+
+            if part_json.exists():
+                logging.info(f"Building part {part_no} for assembly {name}")
+                self.build_part(part_json)
+            else:
+                logging.warning(f"Part JSON not found: {part_json}")
+
+        # Now build the assembly
+        engine = AssemblyOpenSCAD(name=name)
+        engine.set_path(base_path)
+        engine._json_file = json_path
+
+        for part in data["parts"]:
+            engine.add(part)
+
+        try:
+            engine.build(base_path)
+            logging.info(f"Created assembly SCAD file: {name}.scad")
+
+            # Return list of generated files
+            files = [
+                {"file": base_path / f"{name}.scad", "description": "OpenSCAD assembly file"},
+            ]
+
+            return self.file_list(files, self.engine_name, score=3)
+
+        except Exception as error:
+            logging.error(f"Error building OpenSCAD assembly {name}: {error}")
+            return []

--- a/src/examples/unified_engine_example.py
+++ b/src/examples/unified_engine_example.py
@@ -75,11 +75,6 @@ def build_with_freecad():
         # Build - artifacts placed in same directory as JSON files
         artifacts = engine.build(json_files)
 
-        for _artifact in artifacts:
-            pass
-    else:
-        pass
-
 
 if __name__ == "__main__":
     # Build with OpenSCAD

--- a/src/examples/unified_engine_example.py
+++ b/src/examples/unified_engine_example.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2025 Tsolo.io
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Example demonstrating the unified Engine API.
+
+This example shows how to use the unified EngineFreeCAD and EngineOpenSCAD
+classes to build both parts and assemblies from JSON files.
+"""
+
+from pathlib import Path
+
+from cycax.cycad import EngineFreeCAD, EngineOpenSCAD
+
+
+def build_with_openscad():
+    """Build parts and assemblies using the unified OpenSCAD engine."""
+
+    engine = EngineOpenSCAD()
+
+    # Build directory contains both part and assembly JSON files
+    build_dir = Path("./build")
+
+    if not build_dir.exists():
+        return
+
+    # Find some JSON files to build
+    json_files = []
+
+    # Look for a part JSON
+    part_jsons = list(build_dir.glob("**/gear_*.json"))
+    if part_jsons:
+        json_files.append(part_jsons[0])
+
+    # Look for an assembly JSON
+    assembly_jsons = list(build_dir.glob("**/box.json"))
+    if assembly_jsons:
+        json_files.append(assembly_jsons[0])
+
+    if json_files:
+        # Build all files in one call - engine auto-detects parts vs assemblies
+        artifacts = engine.build(json_files)
+
+        for _artifact in artifacts:
+            pass
+    else:
+        pass
+
+
+def build_with_freecad():
+    """Build parts and assemblies using the unified FreeCAD engine."""
+
+    # Configure output formats
+    config = {
+        "out_formats": "STL,PNG",
+        # Optionally specify FreeCAD path:
+        # "freecad_app": "/path/to/FreeCAD.AppImage"
+    }
+
+    engine = EngineFreeCAD(config=config)
+
+    build_dir = Path("./build")
+
+    if not build_dir.exists():
+        return
+
+    # Find JSON files
+    json_files = []
+
+    part_jsons = list(build_dir.glob("**/gear_*.json"))
+    if part_jsons:
+        json_files.append(part_jsons[0])
+
+    if json_files:
+        # Build - artifacts placed in same directory as JSON files
+        artifacts = engine.build(json_files)
+
+        for _artifact in artifacts:
+            pass
+    else:
+        pass
+
+
+if __name__ == "__main__":
+    # Build with OpenSCAD
+    build_with_openscad()
+
+    # Build with FreeCAD (requires FreeCAD to be installed)
+    # Uncomment to test:
+    # build_with_freecad()

--- a/tests/test_assembly_freecad.py
+++ b/tests/test_assembly_freecad.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2025 Tsolo.io
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cycax.cycad import Assembly, AssemblyFreeCAD, SheetMetal
+
+
+def test_freecad_assembly_creation():
+    """Test that FreeCAD assembly engine can be created."""
+    assembly_engine = AssemblyFreeCAD("test_assembly")
+    assert assembly_engine.name == "test_assembly"
+    assert assembly_engine._parts == []
+
+
+def test_freecad_assembly_add_parts():
+    """Test that parts can be added to FreeCAD assembly engine."""
+    assembly_engine = AssemblyFreeCAD("test_assembly")
+
+    part_operation = {
+        "part_no": "test_part",
+        "position": [0, 0, 0],
+        "rotate": [],
+        "rotmax": [10, 10, 10],
+        "colour": "orange",
+        "hash": "test_hash",
+    }
+
+    assembly_engine.add(part_operation)
+    assert len(assembly_engine._parts) == 1
+    assert assembly_engine._parts[0]["part_no"] == "test_part"
+
+
+def test_assembly_get_freecad_assembler():
+    """Test that Assembly class can create FreeCAD assembler."""
+    assembly = Assembly("test_assembly")
+
+    # Test that FreeCAD engine can be retrieved
+    assembler = assembly._get_assembler(engine="FreeCAD")
+    assert isinstance(assembler, AssemblyFreeCAD)
+    assert assembler.name == "test_assembly"
+
+
+def test_assembly_export_for_freecad():
+    """Test that assembly can export data for FreeCAD engine."""
+    assembly = Assembly("box_assembly")
+    part1 = SheetMetal(x_size=100, y_size=50, z_size=2, part_no="bottom")
+    part2 = SheetMetal(x_size=100, y_size=20, z_size=2, part_no="front")
+
+    assembly.add(part1, "bottom")
+    assembly.add(part2, "front")
+
+    # Export assembly data
+    data = assembly.export()
+
+    assert data["name"] == "box_assembly"
+    assert len(data["parts"]) == 2
+    assert data["parts"][0]["part_no"] == "bottom"
+    assert data["parts"][1]["part_no"] == "front"
+
+
+@pytest.mark.ci_exclude
+def test_freecad_assembly_build_without_freecad():
+    """Test FreeCAD assembly build behavior when FreeCAD is not available."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        assembly_engine = AssemblyFreeCAD("test_assembly", config={})
+        assembly_engine._base_path = tmppath
+
+        part_operation = {
+            "part_no": "test_part",
+            "position": [0, 0, 0],
+            "rotate": [],
+            "rotmax": [10, 10, 10],
+            "colour": "orange",
+            "hash": "test_hash",
+        }
+
+        assembly_engine.add(part_operation)
+
+        # This should handle gracefully when FreeCAD is not found
+        # The build method logs errors but doesn't raise exceptions
+        assembly_engine.build(tmppath)
+
+        # Check that assembly JSON was created
+        json_file = tmppath / "test_assembly.json"
+        assert json_file.exists()

--- a/tests/test_unified_engine.py
+++ b/tests/test_unified_engine.py
@@ -1,0 +1,250 @@
+# SPDX-FileCopyrightText: 2025 Tsolo.io
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cycax.cycad.engines import Engine, EngineFreeCAD, EngineOpenSCAD
+
+
+def test_engine_is_part():
+    """Test that Engine can identify part JSON data."""
+    engine = Engine()
+
+    part_data = {"name": "test_part", "features": [{"type": "add", "name": "cube"}]}
+    assert engine.is_part(part_data)
+    assert not engine.is_assembly(part_data)
+
+
+def test_engine_is_assembly():
+    """Test that Engine can identify assembly JSON data."""
+    engine = Engine()
+
+    assembly_data = {"name": "test_assembly", "parts": [{"part_no": "part1"}]}
+    assert engine.is_assembly(assembly_data)
+    assert not engine.is_part(assembly_data)
+
+
+def test_engine_load_json():
+    """Test that Engine can load JSON files."""
+    engine = Engine()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        json_file = Path(tmpdir) / "test.json"
+        test_data = {"name": "test", "features": []}
+        json_file.write_text(json.dumps(test_data))
+
+        loaded_data = engine.load_json(json_file)
+        assert loaded_data == test_data
+
+
+def test_engine_load_json_not_found():
+    """Test that Engine raises error for missing JSON files."""
+    engine = Engine()
+
+    with pytest.raises(FileNotFoundError):
+        engine.load_json(Path("/nonexistent/file.json"))
+
+
+def test_engine_build_part_not_implemented():
+    """Test that base Engine raises NotImplementedError for build_part."""
+    engine = Engine()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        json_file = Path(tmpdir) / "test.json"
+        json_file.write_text(json.dumps({"name": "test", "features": []}))
+
+        with pytest.raises(NotImplementedError):
+            engine.build_part(json_file)
+
+
+def test_engine_build_assembly_not_implemented():
+    """Test that base Engine raises NotImplementedError for build_assembly."""
+    engine = Engine()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        json_file = Path(tmpdir) / "test.json"
+        json_file.write_text(json.dumps({"name": "test", "parts": []}))
+
+        with pytest.raises(NotImplementedError):
+            engine.build_assembly(json_file)
+
+
+def test_engine_file_list():
+    """Test that Engine can generate file lists with metadata."""
+    engine = Engine()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        test_file = tmppath / "test.stl"
+        test_file.write_text("test")
+
+        files = [{"file": test_file}]
+        result = engine.file_list(files, "TestEngine", score=10)
+
+        assert len(result) == 1
+        assert result[0]["type"] == "STL"
+        assert result[0]["engine"] == "TestEngine"
+        assert result[0]["score"] == 10
+
+
+def test_engine_file_list_nonexistent():
+    """Test that Engine handles nonexistent files in file_list."""
+    engine = Engine()
+
+    files = [{"file": Path("/nonexistent/file.stl")}]
+    result = engine.file_list(files, "TestEngine")
+
+    assert len(result) == 0
+
+
+def test_freecad_engine_creation():
+    """Test that FreeCAD engine can be created."""
+    engine = EngineFreeCAD()
+    assert engine.engine_name == "FreeCAD"
+    assert isinstance(engine.config, dict)
+
+
+def test_freecad_engine_with_config():
+    """Test that FreeCAD engine accepts configuration."""
+    config = {"freecad_app": "/usr/bin/freecad", "out_formats": "STL,PNG,DXF"}
+    engine = EngineFreeCAD(config=config)
+    assert engine.config == config
+
+
+def test_openscad_engine_creation():
+    """Test that OpenSCAD engine can be created."""
+    engine = EngineOpenSCAD()
+    assert engine.engine_name == "OpenSCAD"
+    assert isinstance(engine.config, dict)
+
+
+def test_openscad_engine_with_config():
+    """Test that OpenSCAD engine accepts configuration."""
+    config = {"openscad_app": "/usr/bin/openscad"}
+    engine = EngineOpenSCAD(config=config)
+    assert engine.config == config
+
+
+@pytest.mark.ci_exclude
+def test_engine_build_mixed_list():
+    """Test that Engine can build a mixed list of parts and assemblies."""
+    engine = EngineOpenSCAD()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+
+        # Create a part JSON
+        part_dir = tmppath / "test_part"
+        part_dir.mkdir()
+        part_json = part_dir / "test_part.json"
+        part_data = {
+            "name": "test_part",
+            "features": [
+                {
+                    "name": "cube",
+                    "type": "add",
+                    "side": "BOTTOM",
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0,
+                    "x_size": 10,
+                    "y_size": 10,
+                    "z_size": 10,
+                    "center": False,
+                }
+            ],
+            "subtract": [],
+        }
+        part_json.write_text(json.dumps(part_data))
+
+        # Create an assembly JSON
+        assembly_json = tmppath / "test_assembly.json"
+        assembly_data = {
+            "name": "test_assembly",
+            "parts": [
+                {
+                    "part_no": "test_part",
+                    "position": [0, 0, 0],
+                    "rotate": [],
+                    "rotmax": [10, 10, 10],
+                    "colour": "orange",
+                    "hash": "",
+                }
+            ],
+        }
+        assembly_json.write_text(json.dumps(assembly_data))
+
+        # Build both
+        artifacts = engine.build([part_json, assembly_json])
+
+        # Should have generated some artifacts
+        assert isinstance(artifacts, list)
+
+
+def test_freecad_engine_build_part_no_features():
+    """Test FreeCAD engine handling of part with no features."""
+    engine = EngineFreeCAD()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        part_dir = tmppath / "empty_part"
+        part_dir.mkdir()
+        part_json = part_dir / "empty_part.json"
+        part_data = {"name": "empty_part", "features": []}
+        part_json.write_text(json.dumps(part_data))
+
+        # Should return empty list for part with no features
+        artifacts = engine.build_part(part_json)
+        assert artifacts == []
+
+
+def test_freecad_engine_build_assembly_no_parts():
+    """Test FreeCAD engine handling of assembly with no parts."""
+    engine = EngineFreeCAD()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        assembly_json = tmppath / "empty_assembly.json"
+        assembly_data = {"name": "empty_assembly", "parts": []}
+        assembly_json.write_text(json.dumps(assembly_data))
+
+        # Should return empty list for assembly with no parts
+        artifacts = engine.build_assembly(assembly_json)
+        assert artifacts == []
+
+
+def test_openscad_engine_build_part_no_features():
+    """Test OpenSCAD engine handling of part with no features."""
+    engine = EngineOpenSCAD()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        part_dir = tmppath / "empty_part"
+        part_dir.mkdir()
+        part_json = part_dir / "empty_part.json"
+        part_data = {"name": "empty_part", "features": []}
+        part_json.write_text(json.dumps(part_data))
+
+        # Should return empty list for part with no features
+        artifacts = engine.build_part(part_json)
+        assert artifacts == []
+
+
+def test_openscad_engine_build_assembly_no_parts():
+    """Test OpenSCAD engine handling of assembly with no parts."""
+    engine = EngineOpenSCAD()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        assembly_json = tmppath / "empty_assembly.json"
+        assembly_data = {"name": "empty_assembly", "parts": []}
+        assembly_json.write_text(json.dumps(assembly_data))
+
+        # Should return empty list for assembly with no parts
+        artifacts = engine.build_assembly(assembly_json)
+        assert artifacts == []


### PR DESCRIPTION
Add the building of Assemblies using FreeCAD - This places parts relative to one another without any constrains - Constraints are managed in CyCAx.

The first PR is a "whoooot, It works" thats it, will cleanup and improve code on subsequent commits. But please comment if you see issues, I am working on this more off than on.

Things that need attention, documentation, or a conversation:
- Only one script file should exist for FreeCAD an this script file should handle assemblies and parts. I made a copy of the parts one since it was a easy way to get started and not break parts.
- The idea of an engine that does parts and assemblies is quite nice. Need to flesh out the structure of this a bit more.
- Passing in links to the JSON file simplify the logic inside the Engine, I over complicated the old engine.
- The JSON file must exists in the target folder, if you need the artifacts to go somewhere you need to move the JSON first.
- Filenames. I think we should name things `{part name}-{engine name}.{extension}` or `{part name}-{type specific flag}-engine name}.{extension}`.  e.g. `left_side_panel-freecad.step`,  `left_side_panel-front-freecad.png`,  `left_side_panel-left-freecad.png`.